### PR TITLE
Enable to trigger a  workflow manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '35 4 * * 5'
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,6 +2,7 @@ name: 'Dependency Review'
 on:
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
If a pull requests gets created by github-actions (e.g. mark-version-as-released), dependent actions are not executed  automatically (this is by design). With this change, we are able to manually trigger the actions needed to pass the required pr status checks.