### PR TITLE
Fix editing and lock check

### DIFF
--- a/src/client/cypress/e2e/editor/dataCards.cy.js
+++ b/src/client/cypress/e2e/editor/dataCards.cy.js
@@ -1,6 +1,12 @@
-import { createBorehole, handlePrompt, loginAsAdmin, startBoreholeEditing } from "../helpers/testHelpers";
+import {
+  createBorehole,
+  handlePrompt,
+  loginAsAdmin,
+  startBoreholeEditing,
+  stopBoreholeEditing,
+} from "../helpers/testHelpers";
 import { evaluateDisplayValue, evaluateTextarea, setInput, setSelect } from "../helpers/formHelpers";
-import { addItem, saveForm, startEditing, stopEditing } from "../helpers/buttonHelpers";
+import { addItem, saveForm, startEditing } from "../helpers/buttonHelpers";
 
 describe("Tests for the data cards in the editor.", () => {
   it("resets datacards when stop editing", () => {
@@ -13,7 +19,7 @@ describe("Tests for the data cards in the editor.", () => {
     cy.wait(500);
     addItem("addwateringress");
     cy.get('[data-cy="waterIngress-card.0.edit"]').should("exist");
-    stopEditing();
+    stopBoreholeEditing();
     cy.get('[data-cy="waterIngress-card.0.edit"]').should("not.exist");
 
     startBoreholeEditing();
@@ -27,7 +33,7 @@ describe("Tests for the data cards in the editor.", () => {
     cy.wait("@wateringress_GET");
     startEditing();
     setInput("comment", "Lorem.");
-    stopEditing();
+    stopBoreholeEditing();
     evaluateDisplayValue("comment", "-");
   });
 

--- a/src/client/cypress/e2e/editor/dataCards.cy.js
+++ b/src/client/cypress/e2e/editor/dataCards.cy.js
@@ -6,10 +6,10 @@ import {
   stopBoreholeEditing,
 } from "../helpers/testHelpers";
 import { evaluateDisplayValue, evaluateTextarea, setInput, setSelect } from "../helpers/formHelpers";
-import { addItem, saveForm, startEditing } from "../helpers/buttonHelpers";
+import { addItem, cancelEditing, saveForm, startEditing } from "../helpers/buttonHelpers";
 
 describe("Tests for the data cards in the editor.", () => {
-  it("resets datacards when stop editing", () => {
+  it("resets datacards when stop editing or cancel", () => {
     createBorehole({ "extended.original_name": "INTEADAL" }).as("borehole_id");
     cy.get("@borehole_id").then(id => {
       loginAsAdmin(`/${id}/hydrogeology/wateringress`);
@@ -17,6 +17,14 @@ describe("Tests for the data cards in the editor.", () => {
 
     startBoreholeEditing();
     cy.wait(500);
+
+    //Add card and cancel editing in datacard
+    addItem("addwateringress");
+    cy.get('[data-cy="waterIngress-card.0.edit"]').should("exist");
+    cancelEditing();
+    cy.get('[data-cy="waterIngress-card.0.edit"]').should("not.exist");
+
+    //Add card and stop editing borehole
     addItem("addwateringress");
     cy.get('[data-cy="waterIngress-card.0.edit"]').should("exist");
     stopBoreholeEditing();

--- a/src/client/src/AppTheme.ts
+++ b/src/client/src/AppTheme.ts
@@ -53,7 +53,7 @@ export const theme = createTheme({
   typography: {
     fontFamily: "Inter",
     h6: {
-      fontSize: "12px",
+      fontSize: "14px",
       lineHeight: "20px",
       fontWeight: 500,
       color: "#337083",

--- a/src/client/src/AppTheme.ts
+++ b/src/client/src/AppTheme.ts
@@ -53,7 +53,7 @@ export const theme = createTheme({
   typography: {
     fontFamily: "Inter",
     h6: {
-      fontSize: "14px",
+      fontSize: "12px",
       lineHeight: "20px",
       fontWeight: 500,
       color: "#337083",
@@ -236,6 +236,23 @@ export const theme = createTheme({
         root: {
           fontSize: "16px",
           color: "#1c2834",
+        },
+      },
+    },
+    MuiTableCell: {
+      styleOverrides: {
+        head: {
+          fontSize: "13px",
+          fontWeight: 700,
+          padding: "3px",
+          flex: 1,
+          verticalAlign: "top",
+        },
+        body: {
+          paddingRight: "3px",
+          paddingLeft: "3px",
+          flex: 1,
+          fontSize: "13px",
         },
       },
     },

--- a/src/client/src/components/form/formResultTableDisplay.tsx
+++ b/src/client/src/components/form/formResultTableDisplay.tsx
@@ -24,18 +24,11 @@ export const FormResultTableDisplay: React.FC<FormResultTableDisplayProps> = ({
   const { t } = useTranslation();
 
   const tableCellStyles: React.CSSProperties = {
-    paddingRight: "3px",
-    paddingLeft: "3px",
-    flex: 1,
     width: "20%",
     maxWidth: "20%",
-    fontSize: "13px",
   };
 
   const tableHeaderStyles: React.CSSProperties = {
-    fontWeight: 900,
-    padding: "3px",
-    flex: 1,
     width: "20%",
     maxWidth: "20%",
   };

--- a/src/client/src/components/legacyComponents/domain/dropdown/domainDropdown.jsx
+++ b/src/client/src/components/legacyComponents/domain/dropdown/domainDropdown.jsx
@@ -3,9 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { withTranslation } from "react-i18next";
 import _ from "lodash";
-
-import { loadDomains } from "../../../../api-lib/index.js";
-
+import { loadDomains } from "../../../../api-lib";
 import { Form, Header } from "semantic-ui-react";
 
 class DomainDropdown extends React.Component {
@@ -207,7 +205,7 @@ class DomainDropdown extends React.Component {
     );
     if (readOnly) {
       let selectedOption = options.find(option => option.value === selected);
-      return <Form.Input fluid readOnly value={selectedOption.text} />;
+      return <Form.Input fluid readOnly value={selectedOption?.text || ""} />;
     }
     return (
       <Form.Select

--- a/src/client/src/pages/detail/detailHeader.tsx
+++ b/src/client/src/pages/detail/detailHeader.tsx
@@ -1,10 +1,10 @@
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 import { Chip, IconButton, Stack, Typography } from "@mui/material";
 import { theme } from "../../AppTheme.ts";
 import ArrowLeftIcon from "../../assets/icons/arrow_left.svg?react";
 import CheckmarkIcon from "../../assets/icons/checkmark.svg?react";
 import TrashIcon from "../../assets/icons/trash.svg?react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { DeleteButton, EditButton, EndEditButton } from "../../components/buttons/buttons.tsx";
 import { useDispatch, useSelector } from "react-redux";
 import { Borehole, ReduxRootState } from "../../api-lib/ReduxStateInterfaces.ts";
@@ -12,13 +12,16 @@ import { deleteBorehole, lockBorehole, unlockBorehole } from "../../api-lib";
 import { useTranslation } from "react-i18next";
 import { PromptContext } from "../../components/prompt/promptContext.tsx";
 
-const DetailHeader = () => {
-  const [editingEnabled, setEditingEnabled] = useState(false);
-  const [editableByCurrentUser, setEditableByCurrentUser] = useState(false);
+interface DetailHeaderProps {
+  editingEnabled: boolean;
+  setEditingEnabled: (editingEnabled: boolean) => void;
+  editableByCurrentUser: boolean;
+}
+
+const DetailHeader = ({ editingEnabled, setEditingEnabled, editableByCurrentUser }: DetailHeaderProps) => {
   const borehole: Borehole = useSelector((state: ReduxRootState) => state.core_borehole);
   const user = useSelector((state: ReduxRootState) => state.core_user);
   const history = useHistory();
-  const location = useLocation();
   const dispatch = useDispatch();
   const { t } = useTranslation();
   const { showPrompt } = useContext(PromptContext);
@@ -44,28 +47,6 @@ const DetailHeader = () => {
     await deleteBorehole(borehole.data.id);
     history.push("/");
   };
-
-  useEffect(() => {
-    setEditingEnabled(borehole.data.lock !== null);
-  }, [borehole.data.lock]);
-
-  useEffect(() => {
-    if (borehole.data.lock !== null && borehole.data.lock.id !== user.data.id) {
-      setEditableByCurrentUser(false);
-      return;
-    }
-
-    const matchingWorkgroup =
-      user.data.workgroups.find(workgroup => workgroup.id === borehole.data.workgroup?.id) ?? false;
-    const userRoleMatches =
-      matchingWorkgroup &&
-      Object.prototype.hasOwnProperty.call(matchingWorkgroup, "roles") &&
-      matchingWorkgroup.roles.includes(borehole.data.role);
-    const isStatusPage = location.pathname.endsWith("/status");
-    const isBoreholeInEditWorkflow = borehole?.data.workflow?.role === "EDIT";
-
-    setEditableByCurrentUser(userRoleMatches && (isStatusPage || isBoreholeInEditWorkflow));
-  }, [editingEnabled, user, borehole, location]);
 
   if (borehole.isFetching) {
     return;

--- a/src/client/src/pages/detail/detailPage.tsx
+++ b/src/client/src/pages/detail/detailPage.tsx
@@ -1,19 +1,64 @@
 import { LayoutBox, MainContentBox, SidebarBox } from "../../components/styledComponents.ts";
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
+import { Borehole, ReduxRootState } from "../../api-lib/ReduxStateInterfaces.ts";
 import DetailSideNav from "./detailSideNav";
 import DetailPageContent from "./detailPageContent";
 import DetailHeader from "./detailHeader.tsx";
 
+interface DetailPageContentProps {
+  editingEnabled: boolean;
+  editableByCurrentUser: boolean;
+}
+
 export const DetailPage: FC = () => {
+  const [editingEnabled, setEditingEnabled] = useState(false);
+  const [editableByCurrentUser, setEditableByCurrentUser] = useState(false);
+  const borehole: Borehole = useSelector((state: ReduxRootState) => state.core_borehole);
+  const user = useSelector((state: ReduxRootState) => state.core_user);
+  const location = useLocation();
+
+  useEffect(() => {
+    setEditingEnabled(borehole.data.lock !== null);
+  }, [borehole.data.lock]);
+
+  useEffect(() => {
+    if (borehole.data.lock !== null && borehole.data.lock.id !== user.data.id) {
+      setEditableByCurrentUser(false);
+      return;
+    }
+
+    const matchingWorkgroup =
+      user.data.workgroups.find(workgroup => workgroup.id === borehole.data.workgroup?.id) ?? false;
+    const userRoleMatches =
+      matchingWorkgroup &&
+      Object.prototype.hasOwnProperty.call(matchingWorkgroup, "roles") &&
+      matchingWorkgroup.roles.includes(borehole.data.role);
+    const isStatusPage = location.pathname.endsWith("/status");
+    const isBoreholeInEditWorkflow = borehole?.data.workflow?.role === "EDIT";
+
+    setEditableByCurrentUser(userRoleMatches && (isStatusPage || isBoreholeInEditWorkflow));
+  }, [editingEnabled, user, borehole, location]);
+
+  const props: DetailPageContentProps = {
+    editingEnabled: editingEnabled,
+    editableByCurrentUser: editableByCurrentUser,
+  };
+
   return (
     <>
-      <DetailHeader />
+      <DetailHeader
+        editingEnabled={editingEnabled}
+        setEditingEnabled={setEditingEnabled}
+        editableByCurrentUser={editableByCurrentUser}
+      />
       <LayoutBox>
         <SidebarBox>
           <DetailSideNav />
         </SidebarBox>
         <MainContentBox>
-          <DetailPageContent />
+          <DetailPageContent {...props} />
         </MainContentBox>
       </LayoutBox>
     </>

--- a/src/client/src/pages/detail/detailPageContent.jsx
+++ b/src/client/src/pages/detail/detailPageContent.jsx
@@ -105,7 +105,7 @@ class DetailPageContent extends React.Component {
   }
 
   checkLock() {
-    const { t } = this.props;
+    const { t, editingEnabled, editableByCurrentUser } = this.props;
     if (this.props.borehole.data.role !== "EDIT") {
       this.context.showAlert(
         t("common:errorStartEditingWrongStatus", {
@@ -115,8 +115,10 @@ class DetailPageContent extends React.Component {
       );
       return false;
     }
-    if (this.props.borehole.data.lock === null || this.props.borehole.data.lock.id !== this.props.user.data.id) {
-      this.context.showAlert(t("common:errorStartEditing"), "error");
+    if (!editingEnabled) {
+      if (editableByCurrentUser) {
+        this.context.showAlert(t("errorStartEditing"), "error");
+      }
       return false;
     }
     return true;
@@ -127,9 +129,7 @@ class DetailPageContent extends React.Component {
   }
 
   updateNumber(attribute, value, to = true) {
-    if (this.checkLock() === false) {
-      return;
-    }
+    if (!this.checkLock()) return;
     const state = {
       ...this.state,
       patchFetch: true,
@@ -232,10 +232,8 @@ class DetailPageContent extends React.Component {
   }
 
   render() {
-    const { t, borehole, user } = this.props;
+    const { t, borehole, user, editingEnabled } = this.props;
     const size = null; // 'small'
-    const isEditable =
-      borehole?.data.role === "EDIT" && borehole?.data.lock !== null && borehole?.data.lock?.id === user?.data.id;
     if (borehole.error !== null) {
       return <div>{t(borehole.error, borehole.data)}</div>;
     }
@@ -330,24 +328,24 @@ class DetailPageContent extends React.Component {
                     borehole={borehole}
                     updateChange={this.updateChange}
                     updateNumber={this.updateNumber}
-                    isEditable={isEditable}
+                    isEditable={editingEnabled}
                   />
                 )}
               />
               <Route
                 exact
                 path={"/:id/stratigraphy/lithology"}
-                render={() => <Lithology id={parseInt(id, 10)} unlocked={isEditable} />}
+                render={() => <Lithology id={parseInt(id, 10)} unlocked={editingEnabled} checkLock={this.checkLock} />}
               />
               <Route
                 exact
                 path={"/:id/stratigraphy/chronostratigraphy"}
-                render={() => <ChronostratigraphyPanel id={parseInt(id, 10)} isEditable={isEditable} />}
+                render={() => <ChronostratigraphyPanel id={parseInt(id, 10)} isEditable={editingEnabled} />}
               />
               <Route
                 exact
                 path={"/:id/stratigraphy/lithostratigraphy"}
-                render={() => <LithostratigraphyPanel id={parseInt(id, 10)} isEditable={isEditable} />}
+                render={() => <LithostratigraphyPanel id={parseInt(id, 10)} isEditable={editingEnabled} />}
               />
               <Route
                 path={"/:id/stratigraphy"}
@@ -364,27 +362,27 @@ class DetailPageContent extends React.Component {
               <Route
                 exact
                 path={"/:id/attachments"}
-                render={() => <EditorBoreholeFilesTable id={parseInt(id, 10)} unlocked={isEditable} />}
+                render={() => <EditorBoreholeFilesTable id={parseInt(id, 10)} unlocked={editingEnabled} />}
               />
               <Route
                 exact
                 path={"/:id/hydrogeology/wateringress"}
-                render={() => <WaterIngress isEditable={isEditable} boreholeId={parseInt(id, 10)} />}
+                render={() => <WaterIngress isEditable={editingEnabled} boreholeId={parseInt(id, 10)} />}
               />
               <Route
                 exact
                 path={"/:id/hydrogeology/groundwaterlevelmeasurement"}
-                render={() => <GroundwaterLevelMeasurement isEditable={isEditable} boreholeId={parseInt(id, 10)} />}
+                render={() => <GroundwaterLevelMeasurement isEditable={editingEnabled} boreholeId={parseInt(id, 10)} />}
               />
               <Route
                 exact
                 path={"/:id/hydrogeology/fieldmeasurement"}
-                render={() => <FieldMeasurement isEditable={isEditable} boreholeId={parseInt(id, 10)} />}
+                render={() => <FieldMeasurement isEditable={editingEnabled} boreholeId={parseInt(id, 10)} />}
               />
               <Route
                 exact
                 path={"/:id/hydrogeology/hydrotest"}
-                render={() => <Hydrotest isEditable={isEditable} boreholeId={parseInt(id, 10)} />}
+                render={() => <Hydrotest isEditable={editingEnabled} boreholeId={parseInt(id, 10)} />}
               />
               <Route
                 path={"/:id/hydrogeology"}
@@ -400,9 +398,9 @@ class DetailPageContent extends React.Component {
               />
               <Route
                 path={"/:boreholeId/completion/:completionId"}
-                render={() => <Completion isEditable={isEditable} />}
+                render={() => <Completion isEditable={editingEnabled} />}
               />
-              <Route path={"/:boreholeId/completion"} render={() => <Completion isEditable={isEditable} />} />
+              <Route path={"/:boreholeId/completion"} render={() => <Completion isEditable={editingEnabled} />} />
               <Route
                 exact
                 path={"/:id/status"}
@@ -428,6 +426,8 @@ DetailPageContent.propTypes = {
   t: PropTypes.func,
   updateBorehole: PropTypes.func,
   workflow: PropTypes.object,
+  editingEnabled: PropTypes.bool,
+  editableByCurrentUser: PropTypes.bool,
 };
 
 DetailPageContent.defaultProps = {
@@ -455,7 +455,7 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-const ConnectedBoreholeForm = withRouter(
+const ConnectedDetailPageContent = withRouter(
   connect(mapStateToProps, mapDispatchToProps)(withTranslation(["common"])(DetailPageContent)),
 );
-export default ConnectedBoreholeForm;
+export default ConnectedDetailPageContent;

--- a/src/client/src/pages/detail/form/completion/casingDisplay.jsx
+++ b/src/client/src/pages/detail/form/completion/casingDisplay.jsx
@@ -11,19 +11,6 @@ const CasingDisplay = props => {
   const { t, i18n } = useTranslation();
   const domains = useDomains();
 
-  const tableCellStyles = {
-    paddingRight: "3px",
-    paddingLeft: "3px",
-    flex: 1,
-    fontSize: "13px",
-  };
-
-  const tableHeaderStyles = {
-    fontWeight: 900,
-    padding: "3px",
-    flex: 1,
-  };
-
   var depth = extractCasingDepth(item);
 
   return (
@@ -43,24 +30,20 @@ const CasingDisplay = props => {
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ ...tableHeaderStyles, border: "none" }} colSpan={2}>
+              <TableCell sx={{ border: "none" }} colSpan={2}>
                 {t("depthMD")}
               </TableCell>
-              <TableCell sx={tableHeaderStyles} rowSpan={2}>
-                {t("kindCasingLayer")}
-              </TableCell>
-              <TableCell sx={tableHeaderStyles} rowSpan={2}>
-                {t("materialCasingLayer")}
-              </TableCell>
-              <TableCell sx={{ ...tableHeaderStyles, border: "none" }} colSpan={2}>
+              <TableCell rowSpan={2}>{t("kindCasingLayer")}</TableCell>
+              <TableCell rowSpan={2}>{t("materialCasingLayer")}</TableCell>
+              <TableCell sx={{ border: "none" }} colSpan={2}>
                 {t("diameter")}
               </TableCell>
             </TableRow>
             <TableRow>
-              <TableCell sx={{ ...tableHeaderStyles }}>{t("from")}</TableCell>
-              <TableCell sx={tableHeaderStyles}>{t("to")}</TableCell>
-              <TableCell sx={tableHeaderStyles}>{t("inner")}</TableCell>
-              <TableCell sx={tableHeaderStyles}>{t("outer")}</TableCell>
+              <TableCell>{t("from")}</TableCell>
+              <TableCell>{t("to")}</TableCell>
+              <TableCell>{t("inner")}</TableCell>
+              <TableCell>{t("outer")}</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -68,26 +51,20 @@ const CasingDisplay = props => {
               ?.sort((a, b) => a.fromDepth - b.fromDepth)
               .map((element, index) => (
                 <TableRow key={index} sx={{ "&:last-child td, &:last-child th": { border: 0 } }}>
-                  <TableCell
-                    component="th"
-                    scope="row"
-                    sx={tableCellStyles}
-                    data-cy={`casingElements.${index}.fromDepth-formDisplay`}>
+                  <TableCell component="th" scope="row" data-cy={`casingElements.${index}.fromDepth-formDisplay`}>
                     {element.fromDepth}
                   </TableCell>
-                  <TableCell sx={tableCellStyles} data-cy={`casingElements.${index}.toDepth-formDisplay`}>
-                    {element.toDepth}
-                  </TableCell>
-                  <TableCell sx={tableCellStyles} data-cy={`casingElements.${index}.kindId-formDisplay`}>
+                  <TableCell data-cy={`casingElements.${index}.toDepth-formDisplay`}>{element.toDepth}</TableCell>
+                  <TableCell data-cy={`casingElements.${index}.kindId-formDisplay`}>
                     {domains?.data?.find(d => d.id === element.kindId)?.[i18n.language] || ""}
                   </TableCell>
-                  <TableCell sx={tableCellStyles} data-cy={`casingElements.${index}.materialId-formDisplay`}>
+                  <TableCell data-cy={`casingElements.${index}.materialId-formDisplay`}>
                     {domains?.data?.find(d => d.id === element.materialId)?.[i18n.language] || ""}
                   </TableCell>
-                  <TableCell sx={tableCellStyles} data-cy={`casingElements.${index}.innerDiameter-formDisplay`}>
+                  <TableCell data-cy={`casingElements.${index}.innerDiameter-formDisplay`}>
                     {element.innerDiameter}
                   </TableCell>
-                  <TableCell sx={tableCellStyles} data-cy={`casingElements.${index}.outerDiameter-formDisplay`}>
+                  <TableCell data-cy={`casingElements.${index}.outerDiameter-formDisplay`}>
                     {element.outerDiameter}
                   </TableCell>
                 </TableRow>

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithology.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithology.jsx
@@ -9,7 +9,7 @@ import { stratigraphyData } from "./data/stratigraphydata.js";
 import TranslationText from "../../../../../components/legacyComponents/translationText.jsx";
 import { Loader } from "semantic-ui-react";
 
-const Lithology = () => {
+const Lithology = ({ checkLock }) => {
   const { user, borehole } = useSelector(state => ({
     borehole: state.core_borehole,
     user: state.core_user,
@@ -106,6 +106,7 @@ const Lithology = () => {
                 selectedStratigraphyID: selectedStratigraphy ? selectedStratigraphy.id : null,
                 isEditable,
                 onUpdated,
+                checkLock,
                 attribute: attributesBasedKind?.profileInfo,
               }}
             />
@@ -131,6 +132,7 @@ const Lithology = () => {
                   isEditable,
                   onUpdated,
                   reloadAttribute,
+                  checkLock,
                   attribute: attributesBasedKind?.profileAttribute,
                 }}
               />

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyAttributes/lithologyAttributeList/lithologyAttributeList.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyAttributes/lithologyAttributeList/lithologyAttributeList.jsx
@@ -11,9 +11,8 @@ import { useTranslation } from "react-i18next";
 import { parseIfString } from "../../../../../../../components/legacyComponents/formUtils.ts";
 
 const LithologyAttributeList = props => {
-  const { attribute, showAll, updateChange, layer, isVisibleFunction } = props.data;
+  const { attribute, showAll, updateChange, layer, isVisibleFunction, isEditable } = props.data;
   const { t } = useTranslation();
-
   const [inputDisplayValues, setInputDisplayValues] = useState({});
 
   // This adds a delay to each keystroke before calling the updateChange method in the parent component.
@@ -63,6 +62,7 @@ const LithologyAttributeList = props => {
                         item?.isNumber,
                       );
                     }}
+                    readOnly={!isEditable}
                     spellCheck="false"
                     style={{ width: "100%" }}
                     value={
@@ -79,6 +79,7 @@ const LithologyAttributeList = props => {
                     data-cy={item.value}
                     autoCapitalize="off"
                     autoComplete="off"
+                    readOnly={!isEditable}
                     autoCorrect="off"
                     onChange={e => {
                       updateInputDisplayValue(item.value, e.target.value);
@@ -112,6 +113,7 @@ const LithologyAttributeList = props => {
                     debouncedUpdateChange(item.value, e.target.value);
                   }}
                   style={{ width: "100%" }}
+                  readOnly={!isEditable}
                   value={
                     _.isNil(inputDisplayValues[item.value])
                       ? _.isNil(layer?.[item.value])
@@ -156,6 +158,7 @@ const LithologyAttributeList = props => {
                       false,
                     );
                   }}
+                  readOnly={!isEditable}
                   schema={item.schema}
                   search={item.search}
                   selected={_.isNil(layer?.[item.value]) ? null : layer[item.value]}
@@ -172,7 +175,7 @@ const LithologyAttributeList = props => {
                   schema={item.schema}
                   selected={_.isNil(layer?.[item.value]) ? null : layer[item.value]}
                   title={<TranslationText id={item.label} />}
-                  isEditable={true}
+                  isEditable={isEditable}
                 />
               </Styled.AttributesItem>
             )}

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyAttributes/lithologyAttributes.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyAttributes/lithologyAttributes.jsx
@@ -10,7 +10,7 @@ import { AlertContext } from "../../../../../../components/alert/alertContext.ts
 import { fetchLayerById, layerQueryKey, updateLayer } from "../../../../../../api/fetchApiV2.js";
 
 const LithologyAttributes = props => {
-  const { id, isEditable, onUpdated, attribute, reloadAttribute, selectedStratigraphyID } = props.data;
+  const { id, isEditable, checkLock, onUpdated, attribute, reloadAttribute, selectedStratigraphyID } = props.data;
 
   const { codes, geocode } = useSelector(state => ({
     codes: state.core_domain_list,
@@ -88,11 +88,7 @@ const LithologyAttributes = props => {
   }, [id, reloadAttribute, mapResponseToLayer]);
 
   const updateChange = (attribute, value, isNumber = false) => {
-    if (!isEditable) {
-      showAlert(t("common:errorStartEditing"), "error");
-      return;
-    }
-
+    if (!checkLock()) return;
     setState(prevState => ({ ...prevState, isPatching: true }));
     _.set(state.layer, attribute, value);
 
@@ -168,6 +164,7 @@ const LithologyAttributes = props => {
             updateChange,
             layer: state.layer,
             isVisibleFunction,
+            isEditable,
           }}
         />
       )}

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyAttributes/lithologyAttributes.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyAttributes/lithologyAttributes.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as Styled from "./styles.js";
 import { Checkbox } from "semantic-ui-react";
 import _ from "lodash";
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import LithologyAttributeList from "./lithologyAttributeList/lithologyAttributeList.jsx";
 import { useSelector } from "react-redux";
 import { useQueryClient } from "react-query";
-import { AlertContext } from "../../../../../../components/alert/alertContext.tsx";
 import { fetchLayerById, layerQueryKey, updateLayer } from "../../../../../../api/fetchApiV2.js";
 
 const LithologyAttributes = props => {
@@ -56,8 +55,6 @@ const LithologyAttributes = props => {
   });
   const { t } = useTranslation();
   const queryClient = useQueryClient();
-  const { showAlert } = useContext(AlertContext);
-
   const mounted = useRef(false);
 
   const mapResponseToLayer = useCallback(response => {

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyInfo/infoList/InfoList.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyInfo/infoList/InfoList.jsx
@@ -7,8 +7,7 @@ import _ from "lodash";
 import { useCallback, useMemo, useState } from "react";
 
 const InfoList = props => {
-  const { attribute, profileInfo, updateChange } = props.data;
-
+  const { attribute, profileInfo, updateChange, isEditable } = props.data;
   const [inputDisplayValues, setInputDisplayValues] = useState({});
 
   // This adds a delay to each keystroke before calling the updateChange method in the parent component.
@@ -48,6 +47,7 @@ const InfoList = props => {
                     autoCapitalize="off"
                     autoComplete="off"
                     autoCorrect="off"
+                    readOnly={!isEditable}
                     onChange={e => {
                       updateInputDisplayValue(item.value, e.target.value);
                       debouncedUpdateChange(
@@ -74,6 +74,7 @@ const InfoList = props => {
                   <DomainDropdown
                     data-cy={item.value}
                     multiple={item.multiple}
+                    readOnly={!isEditable}
                     onSelected={e => updateChange(item.value, item.multiple ? e.map(mlpr => mlpr.id) : e.id, false)}
                     schema={item.schema}
                     search={item.search}
@@ -85,6 +86,7 @@ const InfoList = props => {
               {item.type === "Date" && (
                 <Styled.AttributesItem>
                   <DateField
+                    isEditable={isEditable}
                     data-cy={item.value}
                     date={profileInfo?.[item.value] ? profileInfo[item.value] : null}
                     onChange={selected => {

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyInfo/lithologyInfo.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyInfo/lithologyInfo.jsx
@@ -1,18 +1,14 @@
-import { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import * as Styled from "./styles.js";
 import InfoList from "./infoList";
 import InfoCheckBox from "./infoCheckBox";
-import { useTranslation } from "react-i18next";
 import { sendProfile } from "./api";
 import { fetchStratigraphy } from "../../../../../../api/fetchApiV2.js";
 import _ from "lodash";
-import { AlertContext } from "../../../../../../components/alert/alertContext.tsx";
 
 const LithologyInfo = props => {
   const { selectedStratigraphyID: id, isEditable, onUpdated, attribute, checkLock } = props.data;
   const mounted = useRef(false);
-  const { t } = useTranslation();
-  const { showAlert } = useContext(AlertContext);
   const [state, setState] = useState({
     isPatching: false,
     updateAttributeDelay: {},

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyInfo/lithologyInfo.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyInfo/lithologyInfo.jsx
@@ -9,8 +9,7 @@ import _ from "lodash";
 import { AlertContext } from "../../../../../../components/alert/alertContext.tsx";
 
 const LithologyInfo = props => {
-  const { selectedStratigraphyID: id, isEditable, onUpdated, attribute } = props.data;
-
+  const { selectedStratigraphyID: id, isEditable, onUpdated, attribute, checkLock } = props.data;
   const mounted = useRef(false);
   const { t } = useTranslation();
   const { showAlert } = useContext(AlertContext);
@@ -45,10 +44,7 @@ const LithologyInfo = props => {
   }, [id, setData]);
 
   const updateChange = (attribute, value, isNumber = false) => {
-    if (!isEditable) {
-      showAlert(t("common:errorStartEditing"), "error");
-      return;
-    }
+    if (!checkLock()) return;
     setState(prevState => ({ ...prevState, isPatching: true }));
     _.set(state.profileInfo, attribute, value);
 
@@ -89,6 +85,7 @@ const LithologyInfo = props => {
           data={{
             attribute,
             updateChange,
+            isEditable,
             profileInfo: state.profileInfo,
           }}
         />

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyLayers/lithologyLayersList/lithologyLayersList.jsx
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyLayers/lithologyLayersList/lithologyLayersList.jsx
@@ -3,7 +3,7 @@ import { Icon, Popup } from "semantic-ui-react";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ModeEditIcon from "@mui/icons-material/ModeEdit";
 import ClearIcon from "@mui/icons-material/Clear";
-import { Stack, Tooltip } from "@mui/material";
+import { Stack, Tooltip, Typography } from "@mui/material";
 import { NumericFormat } from "react-number-format";
 import { withTranslation } from "react-i18next";
 import * as Styled from "./styles.js";
@@ -162,7 +162,7 @@ const LithologyLayersList = props => {
         {showDelete !== itemWithValidation?.id && (
           <>
             <Styled.CardInfo id="info">
-              <Styled.Text warning={isTopHasWarning} id="text">
+              <Typography variant="subtitle1">
                 {isTopHasWarning && <Icon name="warning sign" style={{ color: "red" }} />}
                 {showTopPopup ? (
                   <Popup
@@ -181,23 +181,23 @@ const LithologyLayersList = props => {
                     displayType="text"
                   />
                 )}
-              </Styled.Text>
-
-              <Styled.Text
-                bold
-                style={{
+              </Typography>
+              <Typography
+                variant="body1"
+                sx={{
                   textOverflow: "ellipsis",
                   overflow: "hidden",
+                  lineHeight: "1.2",
+                  fontWeight: "bold",
                   display: "-webkit-box",
                   WebkitLineClamp: "2",
                   WebkitBoxOrient: "vertical",
-                  lineHeight: "1.2",
                 }}>
                 {mainProps}
-              </Styled.Text>
-              <Styled.Text
-                small
-                style={{
+              </Typography>
+              <Typography
+                variant="subtitle2"
+                sx={{
                   textOverflow: "ellipsis",
                   overflow: "hidden",
                   display: "-webkit-box",
@@ -206,8 +206,8 @@ const LithologyLayersList = props => {
                   lineHeight: "1.3",
                 }}>
                 {secondaryProps}
-              </Styled.Text>
-              <Styled.Text warning={isBottomHasWarning}>
+              </Typography>
+              <Typography variant="subtitle1">
                 {isBottomHasWarning && <Icon name="warning sign" style={{ color: "red" }} />}
                 {showBottomPopup ? (
                   <Popup
@@ -227,7 +227,7 @@ const LithologyLayersList = props => {
                     displayType="text"
                   />
                 )}
-              </Styled.Text>
+              </Typography>
             </Styled.CardInfo>
             {isEditable && (
               <Stack direction="row" sx={{ marginLeft: "auto", padding: "3px" }}>

--- a/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyLayers/lithologyLayersList/styles.js
+++ b/src/client/src/pages/detail/form/stratigraphy/lithology/lithologyLayers/lithologyLayersList/styles.js
@@ -1,13 +1,4 @@
 import styled from "styled-components";
-import DomainText from "../../../../../../../components/legacyComponents/domain/domainText.jsx";
-import { Button } from "semantic-ui-react";
-
-export const Layer = styled.div`
-  box-shadow:
-    inset -1px 0 0 lightgrey,
-    inset 0 -1px 0 lightgrey;
-  border-left: 2px solid lightgrey;
-`;
 
 export const MyCard = styled.div`
   display: flex;
@@ -38,25 +29,3 @@ export const CardInfo = styled.div`
   height: 10em;
   max-height: 10em;
 `;
-
-export const CardButtonContainer = styled.div`
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  isolation: isolate;
-`;
-
-export const CardButton = styled(Button)`
-  color: red;
-  isolation: isolate;
-`;
-
-export const Text = styled.div`
-  display: flex;
-  font-weight: ${props => (props.bold ? "bold" : "100")};
-  font-size: ${props => (props.bold ? "14px" : props.small ? "10px" : "13px")};
-  color: ${props => (props.warning ? "red" : props.small ? "grey" : "black")};
-`;
-
-export const DomainTxt = styled(DomainText)``;


### PR DESCRIPTION
Mit dem Viewer Login und dem anonymen Modus waren zum Teil Dropdowns und Radiobuttons aktiv, die readonly hätten sein müssen. Tatsächlich editieren war zwar bereits unmöglich, die Inputs waren allerdings trotzdem aktiv.

@tschumpr irgendwo auf dem Weg diverser Theme-Anpassungen ist der Style der Tables in Completion und Hydrogeology kaputt gegangen. Habe versucht es zu fixen, aber ich weiss nicht mehr genau wie es mal aussah.