### PR TITLE
Fix form reset

### DIFF
--- a/src/client/cypress/e2e/detailPage/boreholeform.cy.js
+++ b/src/client/cypress/e2e/detailPage/boreholeform.cy.js
@@ -1,5 +1,6 @@
-import { evaluateSelect, isDisabled, setSelect } from "../helpers/formHelpers";
-import { createBorehole, goToRouteAndAcceptTerms, newEditableBorehole } from "../helpers/testHelpers";
+import { clickOnRowWithText, showTableAndWaitForData, sortBy } from "../helpers/dataGridHelpers";
+import { evaluateInput, evaluateSelect, isDisabled, setSelect } from "../helpers/formHelpers";
+import { createBorehole, goToRouteAndAcceptTerms, newEditableBorehole, returnToOverview } from "../helpers/testHelpers";
 
 describe("Test for the borehole form.", () => {
   it("Creates a borehole and fills dropdowns.", () => {
@@ -56,6 +57,37 @@ describe("Test for the borehole form.", () => {
       .then(() => {
         expect(boreholeDropdownValues).to.deep.eq(["borehole", "geotechnics", "open, no completion", "2"]);
       });
+  });
+
+  it("Checks if form values are updated when borehole changes", () => {
+    showTableAndWaitForData();
+    // sort by Name descending
+    sortBy("Name");
+    clickOnRowWithText("Zena Rath");
+
+    evaluateSelect("restriction", "");
+    evaluateSelect("national_interest", "0"); // No
+    evaluateSelect("spatial_reference_system", "20104002"); // LV03
+    evaluateSelect("location_precision", "20113005");
+
+    evaluateInput("elevation_z", "3'519.948980314633");
+    evaluateInput("reference_elevation", "3'554.9389396584306");
+    evaluateSelect("elevation_precision", "");
+    evaluateSelect("qt_reference_elevation", "20114007"); // not specified
+    evaluateSelect("reference_elevation_type", "30000013"); // kelly bushing
+
+    returnToOverview();
+    clickOnRowWithText("Zena Mraz");
+    evaluateSelect("restriction", "");
+    evaluateSelect("national_interest", "1"); // Yes
+    evaluateSelect("spatial_reference_system", "20104002"); // LV03
+    evaluateSelect("location_precision", "20113007"); // not specified
+
+    evaluateInput("elevation_z", "3'062.9991330499756");
+    evaluateInput("reference_elevation", "3'478.1368118609007");
+    evaluateSelect("elevation_precision", "20114005"); // 0.1
+    evaluateSelect("qt_reference_elevation", "20114001"); // 10
+    evaluateSelect("reference_elevation_type", "30000013"); // kelly bushing
   });
 
   it("switches tabs", () => {

--- a/src/client/cypress/e2e/detailPage/boreholeform.cy.js
+++ b/src/client/cypress/e2e/detailPage/boreholeform.cy.js
@@ -85,8 +85,8 @@ describe("Test for the borehole form.", () => {
 
     evaluateInput("elevation_z", "3'062.9991330499756");
     evaluateInput("reference_elevation", "3'478.1368118609007");
-    evaluateSelect("elevation_precision", "20114005"); // 0.1
-    evaluateSelect("qt_reference_elevation", "20114001"); // 10
+    evaluateSelect("elevation_precision", "20114003"); // 1
+    evaluateSelect("qt_reference_elevation", "20114005"); // 0.1
     evaluateSelect("reference_elevation_type", "30000013"); // kelly bushing
   });
 

--- a/src/client/cypress/e2e/detailPage/boreholeform.cy.js
+++ b/src/client/cypress/e2e/detailPage/boreholeform.cy.js
@@ -73,8 +73,8 @@ describe("Test for the borehole form.", () => {
     evaluateInput("elevation_z", "3'519.948980314633");
     evaluateInput("reference_elevation", "3'554.9389396584306");
     evaluateSelect("elevation_precision", "");
-    evaluateSelect("qt_reference_elevation", "20114007"); // not specified
-    evaluateSelect("reference_elevation_type", "30000013"); // kelly bushing
+    evaluateSelect("qt_reference_elevation", "");
+    evaluateSelect("reference_elevation_type", "");
 
     returnToOverview();
     clickOnRowWithText("Zena Mraz");

--- a/src/client/public/locale/de/common.json
+++ b/src/client/public/locale/de/common.json
@@ -174,7 +174,6 @@
   "errorMissingBedrockSolution": "Tiefe Top Fels automatisch aus der Bohrdaten übernehmen",
   "errorOverlap": "Überlappende Schichten",
   "errorStartEditing": "Sie sollten die Schaltfläche 'Bearbeitung beginnen' drücken",
-  "errorStartEditingWrongStatus": "Bohrung mit dem Status {{status}} kann nicht editiert werden.",
   "errorStartWrong": "Erste Schicht beginnt nicht auf dem Referenzniveau",
   "errorToDepthTooHigh": "bis Tiefe ist zu gross",
   "errorWrongDepth": "Falsche Bohrendteufe",

--- a/src/client/public/locale/en/common.json
+++ b/src/client/public/locale/en/common.json
@@ -174,7 +174,6 @@
   "errorMissingBedrockSolution": "Take the top bedrock depth automatically from the borehole data",
   "errorOverlap": "Overlapping layers",
   "errorStartEditing": "You should press the 'start editing' button",
-  "errorStartEditingWrongStatus": "Borehole with status {{status}} not editable",
   "errorStartWrong": "First layer does not start at the reference level",
   "errorToDepthTooHigh": "to depth is too high",
   "errorWrongDepth": "Incorrect borehole end depth",

--- a/src/client/public/locale/fr/common.json
+++ b/src/client/public/locale/fr/common.json
@@ -174,7 +174,6 @@
   "errorMissingBedrockSolution": "Reprendre automatiquement la profondeur du toit du rocher à partir de la page des données de forage",
   "errorOverlap": "Des couches se recouvrent",
   "errorStartEditing": "Veuillez appuyer sur le bouton 'Commencer l'édition'",
-  "errorStartEditingWrongStatus": "Forage avec le statut {{status}} non modifiable",
   "errorStartWrong": "La première couche ne débute pas au niveau de la référence altitudinale",
   "errorToDepthTooHigh": "de la profondeur est trop élevée",
   "errorWrongDepth": "Profondeur finale erronée",

--- a/src/client/public/locale/it/common.json
+++ b/src/client/public/locale/it/common.json
@@ -174,7 +174,6 @@
   "errorMissingBedrockSolution": "Crea automaticamente la profondità del substrato roccioso attingendo dai dati inseriti della perforazione",
   "errorOverlap": "Sovrapposizione di strati",
   "errorStartEditing": "Per favore premere il pulsante 'iniziare la modifica'",
-  "errorStartEditingWrongStatus": "Perforazione con stato {{status}} non modificabile",
   "errorStartWrong": "Il primo strato non inizia dalla riferimento della quota",
   "errorToDepthTooHigh": "la profondità è troppo alta",
   "errorWrongDepth": "Profondità di perforazione finale errata",

--- a/src/client/src/components/form/simpleBooleanSelect.tsx
+++ b/src/client/src/components/form/simpleBooleanSelect.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { MenuItem, SxProps } from "@mui/material";
 import { TextField } from "@mui/material/";
-import { FormSelectMenuItem, FormSelectValue } from "./formSelect.tsx";
+import { FormSelectMenuItem } from "./formSelect.tsx";
 
 // This component is needed as an intermediate step to refactor borehole input.
 // The standard form components are not usable with autosave components as they are now.
@@ -15,7 +15,6 @@ interface SimpleBooleanSelectProps {
   disabled?: boolean;
   readonly?: boolean;
   selected?: number | boolean | null;
-  values?: FormSelectValue[];
   sx?: SxProps;
   className?: string;
   onUpdate?: (value: number | boolean | string | null) => void;

--- a/src/client/src/components/form/simpleBooleanSelect.tsx
+++ b/src/client/src/components/form/simpleBooleanSelect.tsx
@@ -2,7 +2,7 @@ import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { MenuItem, SxProps } from "@mui/material";
 import { TextField } from "@mui/material/";
-import { FormSelectMenuItem, FormSelectValue } from "./simpleDomainSelect.tsx";
+import { FormSelectMenuItem, FormSelectValue } from "./formSelect.tsx";
 
 // This component is needed as an intermediate step to refactor borehole input.
 // The standard form components are not usable with autosave components as they are now.

--- a/src/client/src/components/form/simpleBooleanSelect.tsx
+++ b/src/client/src/components/form/simpleBooleanSelect.tsx
@@ -1,0 +1,82 @@
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { MenuItem, SxProps } from "@mui/material";
+import { TextField } from "@mui/material/";
+import { FormSelectMenuItem, FormSelectValue } from "./simpleDomainSelect.tsx";
+
+// This component is needed as an intermediate step to refactor borehole input.
+// The standard form components are not usable with autosave components as they are now.
+// Once the saving mechanism is refactored, this component can be replaced.
+
+interface SimpleBooleanSelectProps {
+  fieldName: string;
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+  readonly?: boolean;
+  selected?: number | boolean | null;
+  values?: FormSelectValue[];
+  sx?: SxProps;
+  className?: string;
+  onUpdate?: (value: number | boolean | string | null) => void;
+}
+
+export const SimpleBooleanSelect: FC<SimpleBooleanSelectProps> = ({
+  fieldName,
+  label,
+  required,
+  disabled,
+  readonly,
+  selected,
+  sx,
+  className,
+  onUpdate,
+}) => {
+  const { t } = useTranslation();
+
+  const menuItems: FormSelectMenuItem[] = [];
+  if (!required) {
+    menuItems.push({ key: 0, value: undefined, label: t("reset"), italic: true });
+  }
+
+  const value = selected === true ? 1 : selected === false ? 0 : 2;
+
+  const values = [
+    { key: 1, name: t("yes") },
+    { key: 0, name: t("no") },
+    { key: 2, name: t("np") },
+  ];
+
+  values.forEach(v =>
+    menuItems.push({
+      key: v.key,
+      value: v.key,
+      label: v.name,
+    }),
+  );
+
+  return (
+    <TextField
+      required={required}
+      className={`${readonly ? "readonly" : ""} ${className || ""}`}
+      select
+      sx={{ ...sx }}
+      label={t(label)}
+      name={fieldName}
+      onChange={e =>
+        onUpdate
+          ? onUpdate(parseInt(e.target.value) === 1 ? true : parseInt(e.target.value) === 0 ? false : null)
+          : null
+      }
+      value={value}
+      disabled={disabled ?? false}
+      data-cy={fieldName + "-formSelect"}
+      InputProps={{ readOnly: readonly, disabled: disabled }}>
+      {menuItems.map(item => (
+        <MenuItem key={item.key} value={item.value}>
+          {item.italic ? <em>{item.label}</em> : item.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};

--- a/src/client/src/components/form/simpleDomainSelect.tsx
+++ b/src/client/src/components/form/simpleDomainSelect.tsx
@@ -1,0 +1,81 @@
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { MenuItem, SxProps } from "@mui/material";
+import { TextField } from "@mui/material/";
+import { useDomains } from "../../../../api/fetchApiV2";
+import { FormSelectMenuItem, FormSelectValue } from "../../../../components/form/formSelect.tsx";
+import { Codelist } from "../../../../components/legacyComponents/domain/domainInterface.ts";
+
+// This component is needed as an intermediate step to refactor borehole input.
+// The standard form components are not usable with autosave components as they are now.
+// Once the saving mechanism is refactored, this component can be replaced.
+
+interface SimpleDomainSelectProps {
+  fieldName: string;
+  schemaName: string;
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+  readonly?: boolean;
+  selected?: number | boolean | null;
+  values?: FormSelectValue[];
+  sx?: SxProps;
+  className?: string;
+  onUpdate?: (value: number | boolean | string | null) => void;
+}
+
+export const SimpleDomainSelect: FC<SimpleDomainSelectProps> = ({
+  fieldName,
+  label,
+  required,
+  disabled,
+  readonly,
+  selected,
+  schemaName,
+  sx,
+  className,
+  onUpdate,
+}) => {
+  const { t, i18n } = useTranslation();
+  const { data: domains } = useDomains();
+
+  const menuItems: FormSelectMenuItem[] = [];
+  if (!required) {
+    menuItems.push({ key: 0, value: undefined, label: t("reset"), italic: true });
+  }
+  domains
+    ?.filter((d: Codelist) => d.schema === schemaName)
+    .sort((a: Codelist, b: Codelist) => a.order - b.order)
+    .forEach((d: Codelist) =>
+      menuItems.push({
+        key: d.id,
+        value: d.id,
+        label: d[i18n.language] as string,
+      }),
+    );
+
+  return (
+    <TextField
+      required={required}
+      className={`${readonly ? "readonly" : ""} ${className || ""}`}
+      select
+      sx={{ ...sx }}
+      label={t(label)}
+      name={fieldName}
+      onChange={e => {
+        if (onUpdate) {
+          onUpdate(e.target.value);
+        }
+      }}
+      value={selected}
+      disabled={disabled ?? false}
+      data-cy={fieldName + "-formSelect"}
+      InputProps={{ readOnly: readonly, disabled: disabled }}>
+      {menuItems.map(item => (
+        <MenuItem key={item.key} value={item.value}>
+          {item.italic ? <em>{item.label}</em> : item.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+};

--- a/src/client/src/components/form/simpleDomainSelect.tsx
+++ b/src/client/src/components/form/simpleDomainSelect.tsx
@@ -2,9 +2,9 @@ import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { MenuItem, SxProps } from "@mui/material";
 import { TextField } from "@mui/material/";
-import { useDomains } from "../../../../api/fetchApiV2";
-import { FormSelectMenuItem, FormSelectValue } from "../../../../components/form/formSelect.tsx";
-import { Codelist } from "../../../../components/legacyComponents/domain/domainInterface.ts";
+import { useDomains } from "../../api/fetchApiV2";
+import { Codelist } from "../legacyComponents/domain/domainInterface.ts";
+import { FormSelectMenuItem, FormSelectValue } from "./formSelect.tsx";
 
 // This component is needed as an intermediate step to refactor borehole input.
 // The standard form components are not usable with autosave components as they are now.

--- a/src/client/src/components/form/simpleDomainSelect.tsx
+++ b/src/client/src/components/form/simpleDomainSelect.tsx
@@ -4,7 +4,7 @@ import { MenuItem, SxProps } from "@mui/material";
 import { TextField } from "@mui/material/";
 import { useDomains } from "../../api/fetchApiV2";
 import { Codelist } from "../legacyComponents/domain/domainInterface.ts";
-import { FormSelectMenuItem, FormSelectValue } from "./formSelect.tsx";
+import { FormSelectMenuItem } from "./formSelect.tsx";
 
 // This component is needed as an intermediate step to refactor borehole input.
 // The standard form components are not usable with autosave components as they are now.
@@ -18,7 +18,6 @@ interface SimpleDomainSelectProps {
   disabled?: boolean;
   readonly?: boolean;
   selected?: number | boolean | null;
-  values?: FormSelectValue[];
   sx?: SxProps;
   className?: string;
   onUpdate?: (value: number | boolean | string | null) => void;

--- a/src/client/src/components/form/simpleFormInput.tsx
+++ b/src/client/src/components/form/simpleFormInput.tsx
@@ -1,0 +1,68 @@
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { InputProps, SxProps, TextField } from "@mui/material";
+import { FormValueType } from "./form.ts";
+import { NumericFormatWithThousandSeparator } from "./numericFormatWithThousandSeparator.tsx";
+
+interface SimpleInputProps {
+  label: string;
+  required?: boolean;
+  disabled?: boolean;
+  readonly?: boolean;
+  type?: FormValueType;
+  multiline?: boolean;
+  rows?: number;
+  value?: string | number | Date | null;
+  sx?: SxProps;
+  className?: string;
+  inputProps?: InputProps;
+  onUpdate?: (value: string) => void;
+  withThousandSeparator?: boolean;
+}
+
+// This component is needed as an intermediate step to refactor borehole input.
+// The standard form components are not usable with autosave components as they are now.
+// Once the saving mechanism is refactored, this component can be replaced.
+
+export const SimpleFormInput: FC<SimpleInputProps> = ({
+  value,
+  className,
+  required,
+  readonly,
+  rows,
+  onUpdate,
+  label,
+  type,
+  multiline,
+  withThousandSeparator,
+  inputProps,
+  disabled,
+  sx,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <TextField
+      required={required || false}
+      sx={{ ...sx }}
+      className={`${readonly ? "readonly" : ""} ${className || ""}`}
+      type={type || FormValueType.Text}
+      multiline={multiline || false}
+      rows={rows}
+      value={value}
+      label={t(label)}
+      data-cy={label + "-formInput"}
+      onChange={e => {
+        if (onUpdate) {
+          onUpdate(e.target.value);
+        }
+      }}
+      InputProps={{
+        ...inputProps /* eslint-disable  @typescript-eslint/no-explicit-any */,
+        ...(withThousandSeparator && { inputComponent: NumericFormatWithThousandSeparator as any }),
+        readOnly: readonly,
+        disabled: disabled,
+      }}
+    />
+  );
+};

--- a/src/client/src/pages/detail/detailPageContent.jsx
+++ b/src/client/src/pages/detail/detailPageContent.jsx
@@ -108,12 +108,6 @@ class DetailPageContent extends React.Component {
   checkLock() {
     const { t, editingEnabled, editableByCurrentUser } = this.props;
     if (this.props.borehole.data.role !== "EDIT") {
-      this.context.showAlert(
-        t("common:errorStartEditingWrongStatus", {
-          status: this.props.borehole.data.role,
-        }),
-        "error",
-      );
       return false;
     }
     if (!editingEnabled) {

--- a/src/client/src/pages/detail/form/location/coordinatesSegment.tsx
+++ b/src/client/src/pages/detail/form/location/coordinatesSegment.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader } from "@mui/material";
 import { fetchApiV2 } from "../../../../api/fetchApiV2.js";
 import { LabelingButton } from "../../../../components/buttons/labelingButton.tsx";
 import { FormContainer, FormCoordinate, FormSelect } from "../../../../components/form/form";
-import { FormDomainSelect } from "../../../../components/form/formDomainSelect.tsx";
+import { SimpleDomainSelect } from "../../../../components/form/simpleDomainSelect.tsx";
 import {
   getPrecisionFromString,
   parseFloatWithThousandsSeparator,
@@ -474,7 +474,7 @@ const CoordinatesSegment: React.FC<CoordinatesSegmentProps> = ({
                     />
                   </FormContainer>
                 </FormContainer>
-                <FormDomainSelect
+                <SimpleDomainSelect
                   fieldName={`location_precision`}
                   label="location_precision"
                   readonly={!editingEnabled}

--- a/src/client/src/pages/detail/form/location/elevationSegment.tsx
+++ b/src/client/src/pages/detail/form/location/elevationSegment.tsx
@@ -16,61 +16,59 @@ const ElevationSegment: FC<ElevationSegmentProps> = ({ borehole, updateChange, u
   const { data: domains } = useDomains();
 
   return (
-    <>
-      <FormSegmentBox>
-        <FormContainer>
-          <FormContainer direction="row">
-            <SimpleFormInput
-              label={"elevation_z"}
-              value={borehole?.data?.elevation_z || ""}
-              withThousandSeparator={true}
-              readonly={!editingEnabled}
-              onUpdate={e => updateNumber("elevation_z", e === "" ? null : parseFloatWithThousandsSeparator(e))}
-            />
-            <SimpleDomainSelect
-              fieldName={"elevation_precision"}
-              label={"elevation_precision"}
-              schemaName={"elevation_precision"}
-              readonly={!editingEnabled}
-              selected={borehole.data.elevation_precision}
-              onUpdate={e => updateChange("elevation_precision", e ?? null, false)}
-            />
-          </FormContainer>
-          <FormContainer direction="row">
-            <SimpleFormInput
-              label={"reference_elevation"}
-              value={borehole?.data?.reference_elevation || ""}
-              withThousandSeparator={true}
-              readonly={!editingEnabled}
-              onUpdate={e => updateNumber("reference_elevation", e === "" ? null : parseFloatWithThousandsSeparator(e))}
-            />
-            <SimpleDomainSelect
-              fieldName={"qt_reference_elevation"}
-              label={"reference_elevation_qt"}
-              readonly={!editingEnabled}
-              schemaName={"elevation_precision"}
-              selected={borehole.data.qt_reference_elevation}
-              onUpdate={e => updateChange("qt_reference_elevation", e ?? null, false)}
-            />
-          </FormContainer>
-          <FormContainer direction="row">
-            <SimpleDomainSelect
-              fieldName={"reference_elevation_type"}
-              label={"reference_elevation_type"}
-              readonly={!editingEnabled}
-              schemaName={"reference_elevation_type"}
-              selected={borehole.data.reference_elevation_type}
-              onUpdate={e => updateChange("reference_elevation_type", e ?? null, false)}
-            />
-            <SimpleFormInput
-              readonly={true}
-              label="height_reference_system"
-              value={domains?.find((d: Codelist) => d.id === borehole.data.height_reference_system)?.code}
-            />
-          </FormContainer>
+    <FormSegmentBox>
+      <FormContainer>
+        <FormContainer direction="row">
+          <SimpleFormInput
+            label={"elevation_z"}
+            value={borehole?.data?.elevation_z || ""}
+            withThousandSeparator={true}
+            readonly={!editingEnabled}
+            onUpdate={e => updateNumber("elevation_z", e === "" ? null : parseFloatWithThousandsSeparator(e))}
+          />
+          <SimpleDomainSelect
+            fieldName={"elevation_precision"}
+            label={"elevation_precision"}
+            schemaName={"elevation_precision"}
+            readonly={!editingEnabled}
+            selected={borehole.data.elevation_precision}
+            onUpdate={e => updateChange("elevation_precision", e ?? null, false)}
+          />
         </FormContainer>
-      </FormSegmentBox>
-    </>
+        <FormContainer direction="row">
+          <SimpleFormInput
+            label={"reference_elevation"}
+            value={borehole?.data?.reference_elevation || ""}
+            withThousandSeparator={true}
+            readonly={!editingEnabled}
+            onUpdate={e => updateNumber("reference_elevation", e === "" ? null : parseFloatWithThousandsSeparator(e))}
+          />
+          <SimpleDomainSelect
+            fieldName={"qt_reference_elevation"}
+            label={"reference_elevation_qt"}
+            readonly={!editingEnabled}
+            schemaName={"elevation_precision"}
+            selected={borehole.data.qt_reference_elevation}
+            onUpdate={e => updateChange("qt_reference_elevation", e ?? null, false)}
+          />
+        </FormContainer>
+        <FormContainer direction="row">
+          <SimpleDomainSelect
+            fieldName={"reference_elevation_type"}
+            label={"reference_elevation_type"}
+            readonly={!editingEnabled}
+            schemaName={"reference_elevation_type"}
+            selected={borehole.data.reference_elevation_type}
+            onUpdate={e => updateChange("reference_elevation_type", e ?? null, false)}
+          />
+          <SimpleFormInput
+            readonly={true}
+            label="height_reference_system"
+            value={domains?.find((d: Codelist) => d.id === borehole.data.height_reference_system)?.code}
+          />
+        </FormContainer>
+      </FormContainer>
+    </FormSegmentBox>
   );
 };
 

--- a/src/client/src/pages/detail/form/location/elevationSegment.tsx
+++ b/src/client/src/pages/detail/form/location/elevationSegment.tsx
@@ -1,9 +1,9 @@
-import { FC, useEffect } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FC } from "react";
 import { Borehole } from "../../../../api-lib/ReduxStateInterfaces.ts";
 import { useDomains } from "../../../../api/fetchApiV2";
-import { FormContainer, FormInput, FormValueType } from "../../../../components/form/form.ts";
-import { FormDomainSelect } from "../../../../components/form/formDomainSelect.tsx";
+import { FormContainer } from "../../../../components/form/form.ts";
+import { SimpleDomainSelect } from "../../../../components/form/simpleDomainSelect.tsx";
+import { SimpleFormInput } from "../../../../components/form/simpleFormInput.tsx";
 import { Codelist } from "../../../../components/legacyComponents/domain/domainInterface.ts";
 import { parseFloatWithThousandsSeparator } from "../../../../components/legacyComponents/formUtils.js";
 import { FormSegmentBox } from "../../../../components/styledComponents.ts";
@@ -15,83 +15,62 @@ interface ElevationSegmentProps extends SegmentProps {
 const ElevationSegment: FC<ElevationSegmentProps> = ({ borehole, updateChange, updateNumber, editingEnabled }) => {
   const { data: domains } = useDomains();
 
-  const formMethods = useForm({
-    mode: "all",
-    defaultValues: borehole.data,
-  });
-
-  useEffect(() => {
-    formMethods.reset(borehole.data);
-  }, [borehole, formMethods]);
-
   return (
-    <FormSegmentBox>
-      <FormProvider {...formMethods}>
+    <>
+      <FormSegmentBox>
         <FormContainer>
           <FormContainer direction="row">
-            <FormInput
-              fieldName={"elevation_z"}
-              label="elevation_z"
-              value={borehole.data.elevation_z ?? ""}
-              type={FormValueType.Text}
-              readonly={!editingEnabled}
+            <SimpleFormInput
+              label={"elevation_z"}
+              value={borehole?.data?.elevation_z || ""}
               withThousandSeparator={true}
+              readonly={!editingEnabled}
               onUpdate={e => updateNumber("elevation_z", e === "" ? null : parseFloatWithThousandsSeparator(e))}
             />
-            <FormDomainSelect
+            <SimpleDomainSelect
               fieldName={"elevation_precision"}
               label={"elevation_precision"}
               schemaName={"elevation_precision"}
               readonly={!editingEnabled}
               selected={borehole.data.elevation_precision}
-              onUpdate={e => {
-                updateChange("elevation_precision", e ?? null, false);
-              }}
+              onUpdate={e => updateChange("elevation_precision", e ?? null, false)}
             />
           </FormContainer>
           <FormContainer direction="row">
-            <FormInput
-              fieldName={"reference_elevation"}
-              label="reference_elevation"
-              value={borehole.data.reference_elevation ?? ""}
-              type={FormValueType.Text}
-              readonly={!editingEnabled}
+            <SimpleFormInput
+              label={"reference_elevation"}
+              value={borehole?.data?.reference_elevation || ""}
               withThousandSeparator={true}
+              readonly={!editingEnabled}
               onUpdate={e => updateNumber("reference_elevation", e === "" ? null : parseFloatWithThousandsSeparator(e))}
             />
-            <FormDomainSelect
+            <SimpleDomainSelect
               fieldName={"qt_reference_elevation"}
               label={"reference_elevation_qt"}
               readonly={!editingEnabled}
               schemaName={"elevation_precision"}
               selected={borehole.data.qt_reference_elevation}
-              onUpdate={e => {
-                updateChange("qt_reference_elevation", e ?? null, false);
-              }}
+              onUpdate={e => updateChange("qt_reference_elevation", e ?? null, false)}
             />
           </FormContainer>
           <FormContainer direction="row">
-            <FormDomainSelect
+            <SimpleDomainSelect
               fieldName={"reference_elevation_type"}
               label={"reference_elevation_type"}
               readonly={!editingEnabled}
               schemaName={"reference_elevation_type"}
               selected={borehole.data.reference_elevation_type}
-              onUpdate={e => {
-                updateChange("reference_elevation_type", e ?? null, false);
-              }}
+              onUpdate={e => updateChange("reference_elevation_type", e ?? null, false)}
             />
-            <FormInput
+            <SimpleFormInput
               readonly={true}
-              fieldName={`height_reference_system`}
               label="height_reference_system"
               value={domains?.find((d: Codelist) => d.id === borehole.data.height_reference_system)?.code}
-              type={FormValueType.Text}
             />
           </FormContainer>
         </FormContainer>
-      </FormProvider>
-    </FormSegmentBox>
+      </FormSegmentBox>
+    </>
   );
 };
 

--- a/src/client/src/pages/detail/form/location/restrictionSegment.tsx
+++ b/src/client/src/pages/detail/form/location/restrictionSegment.tsx
@@ -1,62 +1,68 @@
-import { FormProvider, useForm } from "react-hook-form";
+import { useEffect, useState } from "react";
 import { Card } from "@mui/material";
-import { FormContainer, FormInput, FormValueType } from "../../../../components/form/form.ts";
-import { FormBooleanSelect } from "../../../../components/form/formBooleanSelect.tsx";
-import { FormDomainSelect } from "../../../../components/form/formDomainSelect.tsx";
+import { FormContainer, FormValueType } from "../../../../components/form/form.ts";
+import { SimpleBooleanSelect } from "../../../../components/form/simpleBooleanSelect.tsx";
+import { SimpleDomainSelect } from "../../../../components/form/simpleDomainSelect.tsx";
+import { SimpleFormInput } from "../../../../components/form/simpleFormInput.tsx";
 import { FormSegmentBox } from "../../../../components/styledComponents";
 import { SegmentProps } from "./segmentInterface.ts";
 
-const RestrictionSegment = ({ borehole, updateChange, editingEnabled }: SegmentProps) => {
-  const formMethods = useForm({
-    mode: "all",
-  });
+const restrictionUntilCode = 20111003;
 
-  const restriction = formMethods.watch("restriction");
-  const restrictionUntilCode = 20111003;
+const RestrictionSegment = ({ borehole, updateChange, editingEnabled }: SegmentProps) => {
+  const [restrictionUntilEnabled, setRestrictionUntilEnabled] = useState<boolean>(
+    borehole.data.restriction === restrictionUntilCode,
+  );
+
+  useEffect(() => {
+    if (borehole.data.restriction !== restrictionUntilCode) {
+      setRestrictionUntilEnabled(false);
+    } else {
+      setRestrictionUntilEnabled(true);
+    }
+  }, [borehole.data.restriction]);
 
   return (
-    <FormProvider {...formMethods}>
-      <Card>
-        <FormSegmentBox>
-          <FormContainer direction="row">
-            <FormDomainSelect
-              fieldName={"restriction"}
-              label={"restriction"}
-              schemaName={"restriction"}
-              readonly={!editingEnabled}
-              selected={borehole.data.restriction}
-              onUpdate={e => {
-                if (e !== restrictionUntilCode) {
-                  formMethods.setValue("restriction_until", null);
-                }
-                updateChange("restriction", e ?? null, false);
-              }}
-            />
-            <FormInput
-              fieldName="restriction_until"
-              label="restriction_until"
-              disabled={restriction !== restrictionUntilCode}
-              readonly={!editingEnabled || restriction !== restrictionUntilCode}
-              value={borehole.data.restriction_until}
-              type={FormValueType.Date}
-              onUpdate={selected => {
-                updateChange("restriction_until", selected, false);
-              }}
-            />
-            <FormBooleanSelect
-              required
-              readonly={!editingEnabled}
-              fieldName={"national_interest"}
-              label="national_interest"
-              selected={borehole.data.national_interest}
-              onUpdate={e => {
-                updateChange("national_interest", e, false);
-              }}
-            />
-          </FormContainer>
-        </FormSegmentBox>
-      </Card>
-    </FormProvider>
+    <Card>
+      <FormSegmentBox>
+        <FormContainer direction="row">
+          <SimpleDomainSelect
+            fieldName={"restriction"}
+            label={"restriction"}
+            schemaName={"restriction"}
+            readonly={!editingEnabled}
+            selected={borehole.data.restriction}
+            onUpdate={e => {
+              if (e !== restrictionUntilCode) {
+                setRestrictionUntilEnabled(false);
+                updateChange("restriction_until", "", false);
+              }
+              updateChange("restriction", e ?? null, false);
+            }}
+          />
+          <SimpleFormInput
+            label="restriction_until"
+            disabled={!restrictionUntilEnabled}
+            readonly={!editingEnabled || !restrictionUntilEnabled}
+            value={borehole.data.restriction_until}
+            type={FormValueType.Date}
+            onUpdate={selected => {
+              updateChange("restriction_until", selected, false);
+            }}
+          />
+          <SimpleBooleanSelect
+            required
+            readonly={!editingEnabled}
+            fieldName={"national_interest"}
+            label="national_interest"
+            selected={borehole.data.national_interest}
+            onUpdate={e => {
+              updateChange("national_interest", e, false);
+            }}
+          />
+        </FormContainer>
+      </FormSegmentBox>
+    </Card>
   );
 };
 


### PR DESCRIPTION
@danjov mit den Standard Formkomponenten gab es Probleme, das die Werte zt nicht richtig zurückgesetzt wurden, als ich jetzt das Location Form umgestellt habe und bisher noch das "Save on Change" beibehalten habe. Etwas unglücklich, dass es auch keiner unserer Tests gecached hat. Ich brauche jetzt hier diesen Workaround bis das neue Speicherverhalten umgesetzt ist. 