### PR TITLE
Restriction end date

### DIFF
--- a/src/client/cypress/e2e/detailPage/location.cy.js
+++ b/src/client/cypress/e2e/detailPage/location.cy.js
@@ -1,6 +1,6 @@
 import { addItem, saveWithSaveBar, stopEditing } from "../helpers/buttonHelpers";
 import { checkRowWithText, clickOnRowWithText, showTableAndWaitForData } from "../helpers/dataGridHelpers";
-import { evaluateInput, evaluateSelect, setInput, setSelect } from "../helpers/formHelpers";
+import { evaluateInput, evaluateSelect, isDisabled, setInput, setSelect } from "../helpers/formHelpers";
 import {
   createBorehole,
   goToRouteAndAcceptTerms,
@@ -122,6 +122,21 @@ describe("Tests for 'Location' edit page.", () => {
       saveButton.click();
       verifyNoUnsavedChanges();
     });
+  });
+
+  it.only("Saves restriction until date.", () => {
+    newEditableBorehole().as("borehole_id");
+
+    setSelect("restrictionId", 3);
+    isDisabled("restrictionUntil", false);
+    setInput("restrictionUntil", "2012-11-14");
+    evaluateInput("restrictionUntil", "2012-11-14");
+    saveWithSaveBar();
+    // navigate away and back to check if values are saved
+    cy.get('[data-cy="borehole-menu-item"]').click();
+    cy.get('[data-cy="location-menu-item"]').click();
+
+    evaluateInput("restrictionUntil", "2012-11-14");
   });
 
   it("saves with ctrl s", () => {

--- a/src/client/cypress/e2e/detailPage/location.cy.js
+++ b/src/client/cypress/e2e/detailPage/location.cy.js
@@ -124,7 +124,7 @@ describe("Tests for 'Location' edit page.", () => {
     });
   });
 
-  it.only("Saves restriction until date.", () => {
+  it("Saves restriction until date.", () => {
     newEditableBorehole().as("borehole_id");
 
     setSelect("restrictionId", 3);

--- a/src/client/src/pages/detail/form/location/restrictionSegment.tsx
+++ b/src/client/src/pages/detail/form/location/restrictionSegment.tsx
@@ -25,6 +25,11 @@ const RestrictionSegment = ({ borehole, editingEnabled, formMethods }: Restricti
   const restriction = formMethods.watch("restrictionId");
 
   useEffect(() => {
+    //TODO: Adapt data type on backend to Date instead of slicing the returned DateTime
+    formMethods.setValue("restrictionUntil", borehole.restrictionUntil?.toString().slice(0, 10) ?? "");
+  }, [borehole.restrictionUntil, formMethods]);
+
+  useEffect(() => {
     if (dirtyFields.restrictionId) {
       setRestrictionUntilEnabled(restriction === restrictionUntilCode);
       formMethods.setValue("restrictionUntil", null);


### PR DESCRIPTION
@danjov @Lehats 
Die sauberere Lösung wäre hier den Datentyp im Backend zu ändern. Damit das Datum gleich richtig zurückkommt. 
Das hier ist der Hotfix