### PR TITLE
Add (Copy) to alternate name

### DIFF
--- a/src/api/Controllers/BoreholeController.cs
+++ b/src/api/Controllers/BoreholeController.cs
@@ -313,6 +313,7 @@ public class BoreholeController : BoreholeControllerBase<Borehole>
         borehole.Workflows.Add(new Workflow { Borehole = borehole, Role = Role.Editor, UserId = user.Id });
 
         borehole.OriginalName += " (Copy)";
+        borehole.AlternateName += " (Copy)";
 
         var entityEntry = await Context.AddAsync(borehole).ConfigureAwait(false);
         await Context.SaveChangesAsync().ConfigureAwait(false);

--- a/tests/api/Controllers/BoreholeControllerTest.cs
+++ b/tests/api/Controllers/BoreholeControllerTest.cs
@@ -320,6 +320,7 @@ public class BoreholeControllerTest
         var copiedBorehole = GetBorehole((int)copiedBoreholeId);
 
         Assert.AreEqual($"{originalBorehole.OriginalName} (Copy)", copiedBorehole.OriginalName);
+        Assert.AreEqual($"{originalBorehole.AlternateName} (Copy)", copiedBorehole.AlternateName);
         Assert.AreEqual(originalBorehole.CreatedBy.SubjectId, copiedBorehole.CreatedBy.SubjectId);
         Assert.AreEqual(originalBorehole.UpdatedBy.SubjectId, copiedBorehole.UpdatedBy.SubjectId);
         Assert.AreEqual(DefaultWorkgroupId, copiedBorehole.Workgroup.Id);


### PR DESCRIPTION
Aktuell wird das suffix nur dem OriginalName hinzugefügt und ist daher in der Tabelle und im Titel des Boreholes nicht mehr sichtbar.