### PR TITLE
Hide dropdown arrows if form is not editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Updated the UI design of the tabs component.
 - Reincluded download link for codelist references in the import panel.
 - Formfield border color now depend on whether borehole editing is enabled or not.
+- Select dropdown arrows are now only displayed if borehole editing is enabled.
 
 ### Fixed
 

--- a/src/client/src/components/form/formSelect.tsx
+++ b/src/client/src/components/form/formSelect.tsx
@@ -88,6 +88,11 @@ export const FormSelect: FC<FormSelectProps> = ({
           sx={{
             ...sx,
             ...getFieldBorderColor(isReadOnly),
+            ...(isReadOnly && {
+              "& .MuiSelect-icon": {
+                color: "rgba(0, 0, 0, 0)",
+              },
+            }),
           }}
           className={`${isReadOnly ? "readonly" : ""} ${className ?? ""}`}
           label={t(label)}


### PR DESCRIPTION
Anmerkung von Michael aus dem UX Meeting