### PR TITLE
Simplify and optimize borehole retrieval in test code

### DIFF
--- a/tests/api/BoreholeFileCloudServiceTest.cs
+++ b/tests/api/BoreholeFileCloudServiceTest.cs
@@ -66,7 +66,7 @@ public class BoreholeFileCloudServiceTest
         fileName = fileName.Replace(" ", "_");
 
         // Get borehole with file linked from db
-        var borehole = GetBoreholesWithIncludes(context.Boreholes).Single(b => b.Id == minBoreholeId);
+        var borehole = context.Boreholes.GetAllWithIncludes().Single(b => b.Id == minBoreholeId);
 
         // Check if fileName whitespace is replaced with underscore
         Assert.AreEqual(borehole.BoreholeFiles.First().File.Name, fileName);
@@ -84,7 +84,7 @@ public class BoreholeFileCloudServiceTest
         await boreholeFileUploadService.UploadFileAndLinkToBoreholeAsync(firstPdfFormFile.OpenReadStream(), firstPdfFormFile.FileName, firstPdfFormFile.ContentType, minBoreholeId).ConfigureAwait(false);
 
         // Get borehole with file linked from db
-        var borehole = GetBoreholesWithIncludes(context.Boreholes).Single(b => b.Id == minBoreholeId);
+        var borehole = context.Boreholes.GetAllWithIncludes().Single(b => b.Id == minBoreholeId);
 
         // Check if file is linked to borehole
         Assert.AreEqual(borehole.BoreholeFiles.First().File.Name, fileName);

--- a/tests/api/BoreholeLockServiceTest.cs
+++ b/tests/api/BoreholeLockServiceTest.cs
@@ -230,7 +230,7 @@ public class BoreholeLockServiceTest
     {
         bool LockedCondition(Borehole borehole) => lockedByAdmin ? borehole.LockedById == AdminUserId : borehole.LockedById != AdminUserId;
 
-        return GetBoreholesWithIncludes(context.Boreholes)
+        return context.Boreholes.GetAllWithIncludes()
             .Where(b => b.Workflows.Any(w => w.UserId == AdminUserId))
             .AsEnumerable()
             .First(b => b.Locked.HasValue && LockedCondition(b));

--- a/tests/api/Controllers/BoreholeControllerTest.cs
+++ b/tests/api/Controllers/BoreholeControllerTest.cs
@@ -584,7 +584,7 @@ public class BoreholeControllerTest
         var borehole = context.Boreholes
             .GetAllWithIncludes()
             .AsNoTracking()
-            .ToList()
+            .AsEnumerable()
             .FirstOrDefault(b =>
                 b.Stratigraphies != null &&
                 b.Stratigraphies.Any() &&

--- a/tests/api/Controllers/BoreholeControllerTest.cs
+++ b/tests/api/Controllers/BoreholeControllerTest.cs
@@ -504,8 +504,11 @@ public class BoreholeControllerTest
 
         Assert.AreNotEqual(originalFieldMeasurement.Id, copiedFieldMeasurement.Id);
         Assert.AreNotSame(originalFieldMeasurement.FieldMeasurementResults, copiedFieldMeasurement.FieldMeasurementResults);
-        Assert.AreNotEqual(originalFieldMeasurement.FieldMeasurementResults.First().Id, copiedFieldMeasurement.FieldMeasurementResults.First().Id);
-        Assert.AreEqual(originalFieldMeasurement.FieldMeasurementResults.First().Value, copiedFieldMeasurement.FieldMeasurementResults.First().Value);
+
+        var originalFieldMeasurementResult = originalFieldMeasurement.FieldMeasurementResults.OrderByDescending(x => x.Id).First();
+        var copiedFieldMeasurementResult = copiedFieldMeasurement.FieldMeasurementResults.OrderByDescending(x => x.Id).First();
+        Assert.AreNotEqual(originalFieldMeasurementResult.Id, copiedFieldMeasurementResult.Id);
+        Assert.AreEqual(originalFieldMeasurementResult.Value, copiedFieldMeasurementResult.Value);
 
         var originalSection = originalBorehole.Sections.First();
         var copiedSection = copiedBorehole.Sections.First();
@@ -524,7 +527,7 @@ public class BoreholeControllerTest
 
     private Borehole GetBorehole(int id)
     {
-        return GetBoreholesWithIncludes(context.Boreholes).Single(b => b.Id == id);
+        return context.Boreholes.GetAllWithIncludes().Single(b => b.Id == id);
     }
 
     private Borehole GetBoreholeToAdd()
@@ -617,7 +620,7 @@ public class BoreholeControllerTest
 
     private void LoadBoreholeWithIncludes()
     {
-        List<Borehole> boreholes = GetBoreholesWithIncludes(context.Boreholes).ToList();
+        List<Borehole> boreholes = context.Boreholes.GetAllWithIncludes().ToList();
 
         foreach (var bh in boreholes)
         {

--- a/tests/api/Controllers/ImportControllerTest.cs
+++ b/tests/api/Controllers/ImportControllerTest.cs
@@ -108,10 +108,7 @@ public class ImportControllerTest
         OkObjectResult okResult = (OkObjectResult)response.Result!;
         Assert.AreEqual(2, okResult.Value);
 
-        var boreholes = await context.Boreholes.GetAllWithIncludes().ToListAsync().ConfigureAwait(false);
-
-        var borehole = boreholes.Find(b => b.OriginalName == "PURPLETOLL");
-
+        var borehole = await context.Boreholes.GetAllWithIncludes().SingleAsync(b => b.OriginalName == "PURPLETOLL").ConfigureAwait(false);
         Assert.IsNotNull(borehole.CreatedById, nameof(Borehole.CreatedById).ShouldNotBeNullMessage());
         Assert.IsNotNull(borehole.Created, nameof(Borehole.Created).ShouldNotBeNullMessage());
         Assert.IsNotNull(borehole.UpdatedById, nameof(Borehole.UpdatedById).ShouldNotBeNullMessage());

--- a/tests/api/Controllers/ImportControllerTest.cs
+++ b/tests/api/Controllers/ImportControllerTest.cs
@@ -635,7 +635,7 @@ public class ImportControllerTest
         Assert.AreEqual(6, okResult.Value);
 
         // Assert imported values
-        var borehole = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_6");
+        var borehole = await context.Boreholes.GetAllWithIncludes().SingleAsync(b => b.OriginalName == "Unit_Test_6");
         Assert.AreEqual(1, borehole.WorkgroupId);
         Assert.AreEqual("Unit_Test_6_a", borehole.Name);
         Assert.AreEqual(null, borehole.IsPublic);
@@ -683,7 +683,7 @@ public class ImportControllerTest
         Assert.AreEqual(6, okResult.Value);
 
         // Assert imported values
-        var borehole = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_2");
+        var borehole = await context.Boreholes.GetAllWithIncludes().SingleAsync(b => b.OriginalName == "Unit_Test_2");
         Assert.AreEqual(1, borehole.WorkgroupId);
         Assert.AreEqual(null, borehole.Name);
         Assert.AreEqual(null, borehole.IsPublic);
@@ -722,7 +722,7 @@ public class ImportControllerTest
         Assert.AreEqual(7, okResult.Value);
 
         // Assert imported values
-        var boreholeLV95 = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_2");
+        var boreholeLV95 = await context.Boreholes.GetAllWithIncludes().SingleAsync(b => b.OriginalName == "Unit_Test_2");
         Assert.AreEqual(ReferenceSystem.LV95, boreholeLV95.OriginalReferenceSystem);
         Assert.AreEqual(2000010.12, boreholeLV95.LocationX);
         Assert.AreEqual(1000010.1, boreholeLV95.LocationY);
@@ -731,7 +731,7 @@ public class ImportControllerTest
         Assert.AreEqual(2, boreholeLV95.PrecisionLocationXLV03);
         Assert.AreEqual(2, boreholeLV95.PrecisionLocationYLV03);
 
-        var boreholeLV03 = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_6");
+        var boreholeLV03 = await context.Boreholes.GetAllWithIncludes().SingleAsync(b => b.OriginalName == "Unit_Test_6");
         Assert.AreEqual(ReferenceSystem.LV03, boreholeLV03.OriginalReferenceSystem.Value);
         Assert.AreEqual(20050.12, boreholeLV03.LocationXLV03);
         Assert.AreEqual(10050.12345, boreholeLV03.LocationYLV03);
@@ -740,7 +740,7 @@ public class ImportControllerTest
         Assert.AreEqual(5, boreholeLV03.PrecisionLocationX);
         Assert.AreEqual(5, boreholeLV03.PrecisionLocationY);
 
-        var boreholeWithZeros = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_7");
+        var boreholeWithZeros = await context.Boreholes.GetAllWithIncludes().SingleAsync(b => b.OriginalName == "Unit_Test_7");
         Assert.AreEqual(ReferenceSystem.LV03, boreholeWithZeros.OriginalReferenceSystem.Value);
         Assert.AreEqual(20060.000, boreholeWithZeros.LocationXLV03);
         Assert.AreEqual(10060.0000, boreholeWithZeros.LocationYLV03);

--- a/tests/api/Controllers/ImportControllerTest.cs
+++ b/tests/api/Controllers/ImportControllerTest.cs
@@ -108,7 +108,7 @@ public class ImportControllerTest
         OkObjectResult okResult = (OkObjectResult)response.Result!;
         Assert.AreEqual(2, okResult.Value);
 
-        var boreholes = await GetBoreholesWithIncludes(context.Boreholes).ToListAsync().ConfigureAwait(false);
+        var boreholes = await context.Boreholes.GetAllWithIncludes().ToListAsync().ConfigureAwait(false);
 
         var borehole = boreholes.Find(b => b.OriginalName == "PURPLETOLL");
 
@@ -554,7 +554,7 @@ public class ImportControllerTest
         ActionResultAssert.IsOk(response.Result);
         OkObjectResult okResult = (OkObjectResult)response.Result!;
         Assert.AreEqual(2, okResult.Value);
-        var uploadedBoreholesWithAttachment = await GetBoreholesWithIncludes(context.Boreholes).Where(b => b.OriginalName.StartsWith("Carmen Catnip")).ToListAsync();
+        var uploadedBoreholesWithAttachment = await context.Boreholes.GetAllWithIncludes().Where(b => b.OriginalName.StartsWith("Carmen Catnip")).ToListAsync();
         Assert.AreEqual(uploadedBoreholesWithAttachment.SelectMany(b => b.Files!).Count(), 3);
 
         var firstBoreholes = uploadedBoreholesWithAttachment.Find(b => b.OriginalName == "Carmen Catnip Cheese");
@@ -638,7 +638,7 @@ public class ImportControllerTest
         Assert.AreEqual(6, okResult.Value);
 
         // Assert imported values
-        var borehole = GetBoreholesWithIncludes(context.Boreholes).ToList().Find(b => b.OriginalName == "Unit_Test_6");
+        var borehole = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_6");
         Assert.AreEqual(1, borehole.WorkgroupId);
         Assert.AreEqual("Unit_Test_6_a", borehole.Name);
         Assert.AreEqual(null, borehole.IsPublic);
@@ -686,7 +686,7 @@ public class ImportControllerTest
         Assert.AreEqual(6, okResult.Value);
 
         // Assert imported values
-        var borehole = GetBoreholesWithIncludes(context.Boreholes).ToList().Find(b => b.OriginalName == "Unit_Test_2");
+        var borehole = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_2");
         Assert.AreEqual(1, borehole.WorkgroupId);
         Assert.AreEqual(null, borehole.Name);
         Assert.AreEqual(null, borehole.IsPublic);
@@ -725,7 +725,7 @@ public class ImportControllerTest
         Assert.AreEqual(7, okResult.Value);
 
         // Assert imported values
-        var boreholeLV95 = GetBoreholesWithIncludes(context.Boreholes).ToList().Find(b => b.OriginalName == "Unit_Test_2");
+        var boreholeLV95 = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_2");
         Assert.AreEqual(ReferenceSystem.LV95, boreholeLV95.OriginalReferenceSystem);
         Assert.AreEqual(2000010.12, boreholeLV95.LocationX);
         Assert.AreEqual(1000010.1, boreholeLV95.LocationY);
@@ -734,7 +734,7 @@ public class ImportControllerTest
         Assert.AreEqual(2, boreholeLV95.PrecisionLocationXLV03);
         Assert.AreEqual(2, boreholeLV95.PrecisionLocationYLV03);
 
-        var boreholeLV03 = GetBoreholesWithIncludes(context.Boreholes).ToList().Find(b => b.OriginalName == "Unit_Test_6");
+        var boreholeLV03 = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_6");
         Assert.AreEqual(ReferenceSystem.LV03, boreholeLV03.OriginalReferenceSystem.Value);
         Assert.AreEqual(20050.12, boreholeLV03.LocationXLV03);
         Assert.AreEqual(10050.12345, boreholeLV03.LocationYLV03);
@@ -743,7 +743,7 @@ public class ImportControllerTest
         Assert.AreEqual(5, boreholeLV03.PrecisionLocationX);
         Assert.AreEqual(5, boreholeLV03.PrecisionLocationY);
 
-        var boreholeWithZeros = GetBoreholesWithIncludes(context.Boreholes).ToList().Find(b => b.OriginalName == "Unit_Test_7");
+        var boreholeWithZeros = context.Boreholes.GetAllWithIncludes().Single(b => b.OriginalName == "Unit_Test_7");
         Assert.AreEqual(ReferenceSystem.LV03, boreholeWithZeros.OriginalReferenceSystem.Value);
         Assert.AreEqual(20060.000, boreholeWithZeros.LocationXLV03);
         Assert.AreEqual(10060.0000, boreholeWithZeros.LocationYLV03);

--- a/tests/api/Controllers/SettingsControllerTest.cs
+++ b/tests/api/Controllers/SettingsControllerTest.cs
@@ -2,7 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace BDMS.Tests.Controllers;
+namespace BDMS.Controllers;
 
 [TestClass]
 public class SettingsControllerTest

--- a/tests/api/Controllers/StratigraphyControllerTest.cs
+++ b/tests/api/Controllers/StratigraphyControllerTest.cs
@@ -241,7 +241,7 @@ public class StratigraphyControllerTest
     [TestMethod]
     public async Task Create()
     {
-        var boreholeWithoutStratigraphy = await GetBoreholesWithIncludes(context.Boreholes).FirstAsync(b => !b.Stratigraphies.Any());
+        var boreholeWithoutStratigraphy = await context.Boreholes.GetAllWithIncludes().FirstAsync(b => !b.Stratigraphies.Any());
 
         var stratigraphyToAdd = new Stratigraphy
         {
@@ -265,7 +265,7 @@ public class StratigraphyControllerTest
     [TestMethod]
     public async Task CreateAdditionalStratigraphyForExistingBorehole()
     {
-        var boreholeWithExistingStratigraphy = await GetBoreholesWithIncludes(context.Boreholes).FirstAsync(b => b.Stratigraphies.Any());
+        var boreholeWithExistingStratigraphy = await context.Boreholes.GetAllWithIncludes().FirstAsync(b => b.Stratigraphies.Any());
 
         var stratigraphyToAdd = new Stratigraphy
         {
@@ -404,7 +404,7 @@ public class StratigraphyControllerTest
     {
         // Precondition: Create two stratigraphies for the same borehole,
         // one of which is the main stratigraphy.
-        var boreholeWithoutStratigraphy = await GetBoreholesWithIncludes(context.Boreholes).FirstAsync(b => !b.Stratigraphies.Any());
+        var boreholeWithoutStratigraphy = await context.Boreholes.GetAllWithIncludes().FirstAsync(b => !b.Stratigraphies.Any());
 
         var firstStratigraphy = new Stratigraphy
         {

--- a/tests/api/Helpers.cs
+++ b/tests/api/Helpers.cs
@@ -104,47 +104,6 @@ internal static class Helpers
     }
 
     /// <summary>
-    /// Extends the provided <see cref="IQueryable"/> of type <see cref="Borehole"/> with all includes.
-    /// </summary>
-    /// <param name="query">The <see cref="IQueryable"/> of type <see cref="Borehole"/> to be extended.</param>
-    /// <returns>The extended <see cref="IQueryable"/> of type <see cref="Borehole"/> with all includes.</returns>
-    internal static IQueryable<Borehole> GetBoreholesWithIncludes(IQueryable<Borehole> query)
-    {
-        return query
-            .Include(b => b.BoreholeFiles).ThenInclude(bf => bf.File)
-            .Include(b => b.Files)
-            .Include(b => b.Workflows)
-            .Include(b => b.Workgroup)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.LayerColorCodes)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.LayerDebrisCodes)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.LayerGrainAngularityCodes)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.LayerGrainShapeCodes)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.LayerOrganicComponentCodes)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.LayerUscs3Codes)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.ColorCodelists)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.DebrisCodelists)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.GrainAngularityCodelists)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.GrainShapeCodelists)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.OrganicComponentCodelists)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.Layers).ThenInclude(l => l.Uscs3Codelists)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.LithologicalDescriptions)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.FaciesDescriptions)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.ChronostratigraphyLayers)
-            .Include(b => b.Stratigraphies).ThenInclude(s => s.LithostratigraphyLayers)
-            .Include(b => b.Completions).ThenInclude(c => c.Casings).ThenInclude(c => c.CasingElements)
-            .Include(b => b.Completions).ThenInclude(c => c.Instrumentations)
-            .Include(b => b.Completions).ThenInclude(c => c.Backfills)
-            .Include(b => b.Observations)
-            .Include(b => b.Sections).ThenInclude(s => s.SectionElements)
-            .Include(b => b.BoreholeGeometry)
-            .Include(b => b.BoreholeCodelists)
-            .Include(b => b.CreatedBy)
-            .Include(b => b.UpdatedBy)
-            .Include(b => b.LockedBy)
-            .Include(b => b.Type);
-    }
-
-    /// <summary>
     /// Extends the provided <see cref="IQueryable"/> of type <see cref="Layer"/> with all includes.
     /// </summary>
     /// <param name="query">The <see cref="IQueryable"/> of type <see cref="Layer"/> to be extended.</param>


### PR DESCRIPTION
These changes cut the test execution time almost in half. Further improvements can be made as soon as #1944 is merged.