### PR TITLE
Improve labeling overlay colors

### DIFF
--- a/src/client/cypress/e2e/detailPage/labeling.cy.js
+++ b/src/client/cypress/e2e/detailPage/labeling.cy.js
@@ -124,7 +124,7 @@ function assertBoundingBoxes(totalCount, highlightedArea) {
 function assertClipboardContent(expectedText) {
   cy.window().should(win =>
     win.navigator.clipboard.readText().then(text => {
-      expect(text).to.equal(expectedText); // ✅ Cypress will retry this
+      expect(text).to.equal(expectedText);
     }),
   );
 }

--- a/src/client/cypress/e2e/detailPage/labeling.cy.js
+++ b/src/client/cypress/e2e/detailPage/labeling.cy.js
@@ -9,6 +9,7 @@ import {
   stopBoreholeEditing,
 } from "../helpers/testHelpers.js";
 import "cypress-real-events/support";
+import { getArea } from "ol/sphere.js";
 
 const isFileActive = (fileName, isActive) => {
   cy.contains("span", fileName)
@@ -106,37 +107,26 @@ function assertLabelingAlertText(expectedText) {
     });
 }
 
-function assertBoundingBoxes(totalCount, visibleCount) {
+function assertBoundingBoxes(totalCount, highlightedArea) {
   cy.window().then(win => {
     const layers = win.labelingImage.getLayers().getArray();
     const boundingBoxLayer = layers.find(layer => layer.get("name") === "boundingBoxLayer");
-    const features = boundingBoxLayer.getSource().getFeatures();
-    const featureColors = features.map(feature => {
-      const style = feature.getStyle();
-      return style?.getFill()?.getColor();
-    });
-    expect(features.length).to.equal(totalCount); // layer always contains all bounding boxes, even if they are not visible
-
-    const expectedColors = Array.from({ length: totalCount }, (_, i) =>
-      i < visibleCount ? "rgba(91, 33, 182, 0.2)" : "transparent",
-    );
-    expect(featureColors).to.deep.equal(expectedColors);
+    const highlightsLayer = layers.find(layer => layer.get("name") === "highlightsLayer");
+    const invisibleBoundingBoxes = boundingBoxLayer.getSource().getFeatures();
+    const highlights = highlightsLayer.getSource().getFeatures();
+    expect(invisibleBoundingBoxes.length).to.equal(totalCount); // layer always contains all bounding boxes, even if they are not visible
+    expect(highlights.length).to.equal(highlightedArea === 0 ? 0 : 1); // highlights are combined into one feature
+    highlightedArea !== 0 &&
+      expect(Math.round(Math.abs(getArea(highlights[0].getGeometry())))).to.equal(highlightedArea);
   });
 }
 
 function assertClipboardContent(expectedText) {
-  cy.window().then(win => {
-    const checkClipboard = () =>
-      win.navigator.clipboard.readText().then(text => {
-        if (text !== expectedText) {
-          throw new Error("Clipboard text not updated yet");
-        }
-      });
-
-    cy.wrap(null).should(() => {
-      checkClipboard();
-    });
-  });
+  cy.window().should(win =>
+    win.navigator.clipboard.readText().then(text => {
+      expect(text).to.equal(expectedText); // ✅ Cypress will retry this
+    }),
+  );
 }
 
 describe("Test labeling tool", () => {
@@ -324,7 +314,7 @@ describe("Test labeling tool", () => {
     getElementByDataCy("text-extraction-button").click();
     assertDrawTooltip("Draw box around any text");
     drawBox(200, 120, 500, 400);
-    assertBoundingBoxes(4, 4);
+    assertBoundingBoxes(4, 17227);
     assertLabelingAlertText('Copied to clipboard: "Some information without coo...');
     assertClipboardContent("Some information without coordinates");
 
@@ -332,7 +322,7 @@ describe("Test labeling tool", () => {
     getElementByDataCy("text-extraction-button").click();
     assertDrawTooltip("Draw box around any text");
     drawBox(200, 120, 250, 400);
-    assertBoundingBoxes(4, 1);
+    assertBoundingBoxes(4, 3957);
     assertClipboardContent("Some");
 
     // can switch between text extraction and coordinate extraction

--- a/src/client/src/AppTheme.ts
+++ b/src/client/src/AppTheme.ts
@@ -46,7 +46,7 @@ const themePalette: AppThemePalette = {
     header: "rgba(28, 40, 52, 0.6)",
     main: "#5B21B6",
     mainTransparent: "rgba(91, 33, 182, 0.2)",
-    textHighlights: "rgba(164, 106, 255, 0.5)",
+    textHighlights: "rgba(91, 33, 182, 0.35)",
     mainEnd: "#8B5CF6",
     active: "#4F46E5",
     activeEnd: "#E53940",

--- a/src/client/src/pages/detail/labeling/labelingDrawContainer.tsx
+++ b/src/client/src/pages/detail/labeling/labelingDrawContainer.tsx
@@ -6,8 +6,9 @@ import { defaults as defaultControls } from "ol/control/defaults";
 import { containsCoordinate, Extent, getCenter } from "ol/extent";
 import Feature from "ol/Feature";
 import { Geometry } from "ol/geom";
-import { fromExtent } from "ol/geom/Polygon";
+import Polygon, { fromExtent } from "ol/geom/Polygon";
 import { DragBox, DragRotate, PinchRotate } from "ol/interaction";
+import BaseLayer from "ol/layer/Base";
 import ImageLayer from "ol/layer/Image";
 import VectorLayer from "ol/layer/Vector";
 import Map from "ol/Map";
@@ -115,22 +116,46 @@ export const LabelingDrawContainer: FC<LabelingDrawContainerProps> = ({
     }
   };
 
-  const highlightIntersectingFeatures = (boundingBoxSource: VectorSource, targetFeature: Feature) => {
+  const highlightIntersectingFeatures = (
+    boundingBoxSource: VectorSource,
+    highlightsLayerSource: VectorSource,
+    targetFeature: Feature,
+  ) => {
     const targetExtent = targetFeature.getGeometry()?.getExtent();
     if (!targetExtent) return;
+
+    const intersectingFeatures: Feature[] = [];
 
     boundingBoxSource.getFeatures().forEach(feature => {
       const centroid = getCenter(feature.getGeometry()?.getExtent() ?? []);
       const isIntersecting = centroid && containsCoordinate(targetExtent, centroid);
-
-      feature.setStyle(
-        new Style({
-          fill: new Fill({
-            color: isIntersecting ? theme.palette.ai.mainTransparent : "transparent",
-          }),
-        }),
-      );
+      if (isIntersecting) {
+        intersectingFeatures.push(feature);
+      }
     });
+
+    if (intersectingFeatures.length === 0) return;
+    const mergedCoordinates = intersectingFeatures.flatMap(feature => {
+      const geometry = feature.getGeometry() as Polygon;
+      return geometry.getCoordinates(); // Extract outer rings
+    });
+
+    // Create a new merged Polygon to avoid darkening fill for intersecting bounding boxes
+    const mergedFeature = new Feature(new Polygon(mergedCoordinates));
+    mergedFeature.setStyle(
+      new Style({
+        fill: new Fill({ color: theme.palette.ai.textHighlights }),
+      }),
+    );
+    highlightsLayerSource.clear();
+    highlightsLayerSource.addFeature(mergedFeature);
+  };
+
+  const getSourceFromLayerName = (layers: BaseLayer[], layerName: string): VectorSource | undefined => {
+    const drawingLayer = layers.find(
+      layer => layer instanceof VectorLayer && layer.get("name") === layerName,
+    ) as VectorLayer<Feature<Geometry>>;
+    return drawingLayer?.getSource() as VectorSource | undefined;
   };
 
   useEffect(() => {
@@ -142,19 +167,14 @@ export const LabelingDrawContainer: FC<LabelingDrawContainerProps> = ({
     if (map && drawTooltipLabel) {
       const layers = map.getLayers().getArray();
 
-      const drawingLayer = layers.find(
-        layer => layer instanceof VectorLayer && layer.get("name") === "drawingLayer",
-      ) as VectorLayer<Feature<Geometry>>;
-      const drawingSource = drawingLayer?.getSource() as VectorSource | undefined;
+      const drawingSource = getSourceFromLayerName(layers, "drawingLayer");
+      const boundingBoxSource = getSourceFromLayerName(layers, "boundingBoxLayer");
+      const highlightsSource = getSourceFromLayerName(layers, "highlightsLayer");
 
-      const boundingBoxLayer = layers.find(
-        layer => layer instanceof VectorLayer && layer.get("name") === "boundingBoxLayer",
-      ) as VectorLayer<Feature<Geometry>>;
-      const boundingBoxSource = boundingBoxLayer?.getSource() as VectorSource | undefined;
-
-      if (drawingSource && boundingBoxSource) {
+      if (drawingSource && boundingBoxSource && highlightsSource) {
         drawingSource.clear();
-        boundingBoxSource?.clear();
+        boundingBoxSource.clear();
+        highlightsSource.clear();
         map
           .getInteractions()
           .getArray()
@@ -184,7 +204,7 @@ export const LabelingDrawContainer: FC<LabelingDrawContainerProps> = ({
           const boxFeature = new Feature({
             geometry: fromExtent(dragBox.getGeometry().getExtent()),
           });
-          highlightIntersectingFeatures(boundingBoxSource, boxFeature);
+          highlightIntersectingFeatures(boundingBoxSource, highlightsSource, boxFeature);
         });
 
         dragBox.on("boxend", () => {
@@ -296,8 +316,19 @@ export const LabelingDrawContainer: FC<LabelingDrawContainerProps> = ({
       });
       boundingBoxLayer.set("name", "boundingBoxLayer");
 
+      const highlightSource = new VectorSource();
+      const highlightsLayer = new VectorLayer({
+        source: highlightSource,
+        style: new Style({
+          fill: new Fill({
+            color: theme.palette.ai.mainTransparent,
+          }),
+        }),
+      });
+      highlightsLayer.set("name", "highlightsLayer");
+
       const initMap = new Map({
-        layers: [imageLayer, drawingLayer, boundingBoxLayer],
+        layers: [imageLayer, drawingLayer, boundingBoxLayer, highlightsLayer],
         target: "map",
         controls: defaultControls({
           attribution: false,


### PR DESCRIPTION
Da bei einigen PDF die boundingboxes für die Wörter überlappen wurden die transparenten Farben überlagert und daher dunkler. 
Das machte die Darstellung sehr unübersichtlich.
Jetzt werden alle gehighlighteten Features zu einem kombiniert