### PR TITLE
Upgrade PostgreSQL Testcontainers NuGet package

### DIFF
--- a/tests/extern-sync/BDMS.ExternSync.Test.csproj
+++ b/tests/extern-sync/BDMS.ExternSync.Test.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
to the latest version available.

This hopefully fixes a database connection timeout which occurs at irregular intervals.

#1474