### PR TITLE
Update extern-sync logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Updated _extern-sync_ logic to filter published boreholes by target workgroup for duplication check.
+
 ## v2.1.1200 - 2025-05-22
 
 ### Added

--- a/tests/extern-sync/Tasks/SyncBoreholesTaskTest.cs
+++ b/tests/extern-sync/Tasks/SyncBoreholesTaskTest.cs
@@ -70,7 +70,7 @@ public class SyncBoreholesTaskTest
     [TestMethod]
     public async Task SyncBoreholesForEmpty()
     {
-        using var syncContext = await TestSyncContext.BuildAsync(useInMemory: true);
+        using var syncContext = await TestSyncContext.BuildAsync(seedTestDataInSourceContext: false);
         using var syncTask = new SyncBoreholesTask(syncContext, Mock.Of<ILogger<SyncBoreholesTask>>(), GetDefaultConfiguration());
 
         var cancellationToken = Mock.Of<CancellationTokenSource>().Token;


### PR DESCRIPTION
Updated the synchronization logic in the `SyncBoreholesTask` class to ensure that only published boreholes relevant to the target workgroup are considered during the duplication check.

Resolves #2062 