### PR TITLE
Sync boreholes with status reviewed or published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - _view-sync_ now also syncs published public attachments.
 - Adding or importing boreholes is now explicitly disabled when no workgroup is selected.
 - Moved geometry format names to localization files to support translations.
+- _extern-sync_ now syncs all boreholes once they reach the `Reviewed` status.
 
 ### Fixed
 - Boreholes that were locked by any user could not be edited by others, including administrators, even after lock timeout expiration.

--- a/src/extern-sync/SyncContextExtensions.cs
+++ b/src/extern-sync/SyncContextExtensions.cs
@@ -50,10 +50,11 @@ public static class SyncContextExtensions
         new DbContextOptionsBuilder<BdmsContext>().UseNpgsql(connectionString, BdmsContextExtensions.SetDbContextOptions).Options;
 
     /// <summary>
-    /// Filters the given <paramref name="boreholes"/> and returns only those with status published.
+    /// Filters the given <paramref name="boreholes"/> and returns only those with status
+    /// <see cref="WorkflowStatus.Reviewed"/> or <see cref="WorkflowStatus.Published"/>.
     /// </summary>
-    internal static IEnumerable<Borehole> WithStatusPublished(this IEnumerable<Borehole> boreholes)
-        => boreholes.Where(b => b.Workflow?.Status == WorkflowStatus.Published);
+    internal static IEnumerable<Borehole> WithStatusReviewedOrPublished(this IEnumerable<Borehole> boreholes)
+        => boreholes.Where(b => b.Workflow?.Status == WorkflowStatus.Reviewed || b.Workflow?.Status == WorkflowStatus.Published);
 
     /// <summary>
     /// Recursively marks the given <paramref name="items"/> and all their dependencies as new.

--- a/src/extern-sync/Tasks/SyncBoreholesTask.cs
+++ b/src/extern-sync/Tasks/SyncBoreholesTask.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 namespace BDMS.ExternSync.Tasks;
 
 /// <summary>
-/// Sync <see cref="Borehole"/>s with publication status 'published' from a source to a destination context.
+/// Syncs <see cref="Borehole"/>s with workflow status 'reviewed' or 'published' from a source to a destination context.
 /// </summary>
 public class SyncBoreholesTask(ISyncContext syncContext, ILogger<SyncBoreholesTask> logger, IConfiguration configuration)
     : SyncTask(syncContext, logger, configuration)
@@ -37,14 +37,14 @@ public class SyncBoreholesTask(ISyncContext syncContext, ILogger<SyncBoreholesTa
         // Get published boreholes from the source database.
         var publishedBoreholes = Source.BoreholesWithIncludes
             .AsNoTrackingWithIdentityResolution()
-            .WithStatusPublished()
+            .WithStatusReviewedOrPublished()
             .ToList();
 
         // Skip this sync task if there are no published boreholes available.
         if (publishedBoreholes.Count == 0)
         {
             Logger.LogInformation(
-                "No (new) boreholes in publication status 'published' found on source database. Skipping task...");
+                "No (new) boreholes with workflow status 'reviewed' or 'published' found on source database. Skipping task...");
             return;
         }
 

--- a/src/extern-sync/db-init/01_set_workflow_status.sh
+++ b/src/extern-sync/db-init/01_set_workflow_status.sh
@@ -2,7 +2,7 @@
 
 # ------------------------------------------------------------------------------
 # DESCRIPTION: As part of the docker-entrypoint initialization, this script
-#              sets the publication status for some boreholes to 'published'.
+#              sets the workflow status for some boreholes to 'reviewed'.
 #              Only lightweight boreholes, with an id greater than 1000100, are
 #              used, because the full blown do not meet the requirements
 #              regarding the use of casings.
@@ -26,7 +26,7 @@ psql \
       BEGIN
           -- Update workflow status
           UPDATE $SOURCE_DB_SCHEMA.workflow
-          SET status = 3
+          SET status = 2 -- workflow status 'reviewed'
           WHERE borehole_id = ANY(bho_ids);
 
           -- Update tab_status for all workflow entries related to these boreholes

--- a/tests/extern-sync/SyncContextExtensionsTest.cs
+++ b/tests/extern-sync/SyncContextExtensionsTest.cs
@@ -28,21 +28,23 @@ public class SyncContextExtensionsTest
     }
 
     [TestMethod]
-    public async Task GetWithPublicationStatusPublished()
+    public async Task GetBoreholesWithStatusReviewedOrPublished()
     {
-        // Set the publication status for some boreholes. By default all seeded boreholes have the publication status 'change in progress'.
+        // Set the workflow status for some boreholes. By default all seeded boreholes
+        // have the default workflow status 'draft'.
         var cancellationToken = Mock.Of<CancellationTokenSource>().Token;
         await context.SetBoreholeStatusAsync(1_000_001, WorkflowStatus.Draft, cancellationToken);
         await context.SetBoreholeStatusAsync(1_000_020, WorkflowStatus.InReview, cancellationToken);
-        await context.SetBoreholeStatusAsync(1_000_444, WorkflowStatus.Reviewed, cancellationToken);
 
-        await context.SetBoreholeStatusAsync(1_000_300, WorkflowStatus.Published, cancellationToken);
-        await context.SetBoreholeStatusAsync(1_001_555, WorkflowStatus.Published, cancellationToken);
+        await context.SetBoreholeStatusAsync(1_000_444, WorkflowStatus.Reviewed, cancellationToken);
+        await context.SetBoreholeStatusAsync(1_000_300, WorkflowStatus.Reviewed, cancellationToken);
+        await context.SetBoreholeStatusAsync(1_001_555, WorkflowStatus.Reviewed, cancellationToken);
         await context.SetBoreholeStatusAsync(1_000_666, WorkflowStatus.Published, cancellationToken);
 
-        var boreholes = context.Boreholes.WithStatusPublished().ToList();
+        var boreholes = context.Boreholes.WithStatusReviewedOrPublished().ToList();
 
-        Assert.AreEqual(3, boreholes.Count);
+        Assert.AreEqual(4, boreholes.Count);
+        Assert.IsNotNull(boreholes.SingleOrDefault(b => b.Id == 1_000_444));
         Assert.IsNotNull(boreholes.SingleOrDefault(b => b.Id == 1_000_300));
         Assert.IsNotNull(boreholes.SingleOrDefault(b => b.Id == 1_001_555));
         Assert.IsNotNull(boreholes.SingleOrDefault(b => b.Id == 1_000_666));

--- a/tests/extern-sync/TestSyncContextExtensions.cs
+++ b/tests/extern-sync/TestSyncContextExtensions.cs
@@ -59,7 +59,7 @@ internal static class TestSyncContextExtensions
     /// <summary>
     /// Sets the workflow <paramref name="status"/> for this <paramref name="borehole"/>.
     /// </summary>
-    /// <param name="borehole">The <see cref="Borehole"/> to set the publication status on.</param>
+    /// <param name="borehole">The <see cref="Borehole"/> to set the workflow status on.</param>
     /// <param name="status">The <see cref="WorkflowStatus"/> to be set.</param>
     internal static Borehole SetBoreholeWorkflowStatus(this Borehole borehole, WorkflowStatus status)
     {
@@ -71,10 +71,10 @@ internal static class TestSyncContextExtensions
     }
 
     /// <summary>
-    /// Sets the publication <paramref name="status"/> for the specified <paramref name="boreholeId"/>.
+    /// Sets the workflow <paramref name="status"/> for the specified <paramref name="boreholeId"/>.
     /// </summary>
     /// <param name="context">The database context to be used.</param>
-    /// <param name="boreholeId">The <see cref="Borehole.Id"/> to set the publication state on.</param>
+    /// <param name="boreholeId">The <see cref="Borehole.Id"/> to set the workflow status on.</param>
     /// <param name="status">The <see cref="WorkflowStatus"/> to be set.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/>.</param>
     /// <returns>The updated <see cref="Borehole"/> entity.</returns>
@@ -173,11 +173,11 @@ internal static class TestSyncContextExtensions
     /// <see cref="Casing"/>s in <see cref="Instrumentation"/>s, <see cref="Backfill"/>s and <see cref="Observation"/>s
     /// are expected to be also available in <see cref="Completion"/>s. Our test data seeded with
     /// <see cref="BdmsContextExtensions.SeedData(BdmsContext)"/> does not meet these requirements atm. This method fixes
-    /// <see cref="Borehole"/>s with publication status 'published' only and can be executed multiple times.
+    /// <see cref="Borehole"/>s with workflow status 'reviewed' or 'published' only and can be executed multiple times.
     /// </summary>
     internal static async Task FixCasingReferencesAsync(this BdmsContext context, CancellationToken cancellationToken)
     {
-        var boreholes = context.BoreholesWithIncludes.WithStatusPublished();
+        var boreholes = context.BoreholesWithIncludes.WithStatusReviewedOrPublished();
 
         foreach (var borehole in boreholes)
         {


### PR DESCRIPTION
Also update the term which is used in functions and comments to describe the status of a borehole.

Resolves #2296