### PR TITLE
Fix large log file export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - Upgraded to .NET 10.
 
+### Fixed
+- Exporting log runs with large attachments no longer fails. Log file exports and downloads are streamed instead of being assembled in memory, so files larger than 2 GB can now be exported and downloaded up to the 5 GB limit.
+
 ## v2.1.1748 - 2026-07-28
 
 ### Changed

--- a/src/api/Controllers/LogController.cs
+++ b/src/api/Controllers/LogController.cs
@@ -160,9 +160,9 @@ public class LogController : BoreholeControllerBase<LogRun>
 
             if (!await BoreholePermissionService.CanViewBoreholeAsync(HttpContext.GetUserSubjectId(), logFile.LogRun.BoreholeId).ConfigureAwait(false)) return Unauthorized();
 
-            var fileBytes = await logFileCloudService.GetObject(logFile.NameUuid).ConfigureAwait(false);
+            var fileStream = await logFileCloudService.GetObjectStream(logFile.NameUuid).ConfigureAwait(false);
 
-            return File(fileBytes, "application/octet-stream", logFile.Name);
+            return File(fileStream, "application/octet-stream", logFile.Name);
         }
         catch (Exception ex)
         {

--- a/src/api/Controllers/LogController.cs
+++ b/src/api/Controllers/LogController.cs
@@ -141,15 +141,16 @@ public class LogController : BoreholeControllerBase<LogRun>
     /// Downloads a log file from the cloud storage.
     /// </summary>
     /// <param name="id">The <see cref="LogFile.Id"/> of the file to download.</param>
+    /// <param name="cancellationToken">Aborts the download once the client is gone.</param>
     /// <returns>The stream of the downloaded file.</returns>
     [HttpGet("download")]
     [Authorize(Policy = PolicyNames.Viewer)]
-    public async Task<IActionResult> DownloadAsync([Range(1, int.MaxValue)] int id)
+    public async Task<IActionResult> DownloadAsync([Range(1, int.MaxValue)] int id, CancellationToken cancellationToken)
     {
         try
         {
             var logFile = await Context.LogFiles
-                .FirstOrDefaultAsync(f => f.Id == id)
+                .FirstOrDefaultAsync(f => f.Id == id, cancellationToken)
                 .ConfigureAwait(false);
 
             if (logFile == null || logFile.NameUuid == null)
@@ -159,7 +160,7 @@ public class LogController : BoreholeControllerBase<LogRun>
 
             if (!await BoreholePermissionService.CanViewBoreholeAsync(HttpContext.GetUserSubjectId(), logFile.LogRun.BoreholeId).ConfigureAwait(false)) return Unauthorized();
 
-            var fileStream = await logFileCloudService.GetObjectStream(logFile.NameUuid).ConfigureAwait(false);
+            var fileStream = await logFileCloudService.GetObjectStream(logFile.NameUuid, cancellationToken).ConfigureAwait(false);
 
             return File(fileStream, "application/octet-stream", logFile.Name);
         }
@@ -663,11 +664,13 @@ public class LogController : BoreholeControllerBase<LogRun>
     /// <summary>
     /// Exports log runs or log files as a ZIP archive containing CSV files and optionally the file attachments.
     /// </summary>
+    /// <param name="request">The log runs or log files to export.</param>
+    /// <param name="cancellationToken">Aborts the export once the client is gone. An export can transfer several gigabytes, so the work it triggers must not outlive the request.</param>
     [HttpPost("export")]
     [Authorize(Policy = PolicyNames.Viewer)]
-    public async Task<IActionResult> ExportAsync([FromBody] LogExportRequest request)
+    public async Task<IActionResult> ExportAsync([FromBody] LogExportRequest request, CancellationToken cancellationToken)
     {
-        var (logRuns, logFiles, error) = await LoadLogExportDataAsync(request).ConfigureAwait(false);
+        var (logRuns, logFiles, error) = await LoadLogExportDataAsync(request, cancellationToken).ConfigureAwait(false);
         if (error != null) return error;
 
         if (!await BoreholePermissionService.CanViewBoreholeAsync(HttpContext.GetUserSubjectId(), logRuns[0].BoreholeId).ConfigureAwait(false)) return Unauthorized();
@@ -702,7 +705,7 @@ public class LogController : BoreholeControllerBase<LogRun>
                 var probes = await Task.WhenAll(attachments.Select(async logFile => new
                 {
                     LogFile = logFile,
-                    Exists = await logFileCloudService.ObjectExists(logFile.NameUuid!).ConfigureAwait(false),
+                    Exists = await logFileCloudService.ObjectExists(logFile.NameUuid!, cancellationToken).ConfigureAwait(false),
                 })).ConfigureAwait(false);
 
                 var missingFileNames = probes.Where(probe => !probe.Exists).Select(probe => probe.LogFile.Name).ToList();
@@ -719,7 +722,7 @@ public class LogController : BoreholeControllerBase<LogRun>
                     var nameUuid = logFile.NameUuid!;
                     entries.Add(new ZipEntrySource(
                         $"{folderName}/{fileName}",
-                        () => logFileCloudService.GetObjectStream(nameUuid)));
+                        entryCancellationToken => logFileCloudService.GetObjectStream(nameUuid, entryCancellationToken)));
                 }
             }
 
@@ -737,7 +740,7 @@ public class LogController : BoreholeControllerBase<LogRun>
         }
     }
 
-    private async Task<(List<LogRun> LogRuns, List<LogFile> LogFiles, IActionResult? Error)> LoadLogExportDataAsync(LogExportRequest request)
+    private async Task<(List<LogRun> LogRuns, List<LogFile> LogFiles, IActionResult? Error)> LoadLogExportDataAsync(LogExportRequest request, CancellationToken cancellationToken)
     {
         if (request.LogRunIds.Count == 0 && request.LogFileIds.Count == 0)
             return ([], [], BadRequest("No ids were provided."));
@@ -749,7 +752,7 @@ public class LogController : BoreholeControllerBase<LogRun>
         {
             var logRuns = await LogRunsForExport
                 .Where(lr => request.LogRunIds.Contains(lr.Id))
-                .ToListAsync()
+                .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             if (logRuns.Count == 0) return ([], [], NotFound());
@@ -759,7 +762,7 @@ public class LogController : BoreholeControllerBase<LogRun>
 
             var logFiles = await LogFilesForExport
                 .Where(lf => request.LogRunIds.Contains(lf.LogRunId))
-                .ToListAsync()
+                .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
             return (logRuns, logFiles, null);
@@ -767,7 +770,7 @@ public class LogController : BoreholeControllerBase<LogRun>
 
         var logFilesResult = await LogFilesForExport
             .Where(lf => request.LogFileIds.Contains(lf.Id))
-            .ToListAsync()
+            .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
         if (logFilesResult.Count == 0) return ([], [], NotFound());
@@ -777,7 +780,7 @@ public class LogController : BoreholeControllerBase<LogRun>
 
         var logRunsResult = await LogRunsForExport
             .Where(lr => lr.Id == logRunIds[0])
-            .ToListAsync()
+            .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
         if (logRunsResult.Count == 0) return ([], [], NotFound());

--- a/src/api/Controllers/LogController.cs
+++ b/src/api/Controllers/LogController.cs
@@ -685,14 +685,14 @@ public class LogController : BoreholeControllerBase<LogRun>
             var logRunCsvBytes = await WriteLogRunCsvBytesAsync(logRuns, request.Locale).ConfigureAwait(false);
             entries.Add(new ZipEntrySource(
                 $"{LogRunExportFileName}_{timestamp}.csv",
-                () => Task.FromResult<Stream>(new MemoryStream(logRunCsvBytes))));
+                _ => Task.FromResult<Stream>(new MemoryStream(logRunCsvBytes))));
 
             if (logFiles.Count > 0)
             {
                 var logFileCsvBytes = await WriteLogFileCsvBytesAsync(logFiles, request.Locale).ConfigureAwait(false);
                 entries.Add(new ZipEntrySource(
                     $"{LogFileExportFileName}_{timestamp}.csv",
-                    () => Task.FromResult<Stream>(new MemoryStream(logFileCsvBytes))));
+                    _ => Task.FromResult<Stream>(new MemoryStream(logFileCsvBytes))));
             }
 
             if (request.WithAttachments == true)

--- a/src/api/Controllers/LogController.cs
+++ b/src/api/Controllers/LogController.cs
@@ -10,7 +10,6 @@ using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Globalization;
-using System.IO.Compression;
 using System.Text;
 
 namespace BDMS.Controllers;
@@ -676,43 +675,55 @@ public class LogController : BoreholeControllerBase<LogRun>
         try
         {
             var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
-            using var memoryStream = new MemoryStream();
-            using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, true))
+            var entries = new List<ZipEntrySource>();
+
+            // The CSVs are generated in memory anyway and are small, so they stay buffered.
+            // Only the attachments, which can be several gigabytes each, are streamed.
+            var logRunCsvBytes = await WriteLogRunCsvBytesAsync(logRuns, request.Locale).ConfigureAwait(false);
+            entries.Add(new ZipEntrySource(
+                $"{LogRunExportFileName}_{timestamp}.csv",
+                () => Task.FromResult<Stream>(new MemoryStream(logRunCsvBytes))));
+
+            if (logFiles.Count > 0)
             {
-                var logRunCsvBytes = await WriteLogRunCsvBytesAsync(logRuns, request.Locale).ConfigureAwait(false);
-                var logRunCsvEntry = archive.CreateEntry($"{LogRunExportFileName}_{timestamp}.csv", CompressionLevel.Fastest);
-                using (var logRunCsvStream = await logRunCsvEntry.OpenAsync().ConfigureAwait(false))
+                var logFileCsvBytes = await WriteLogFileCsvBytesAsync(logFiles, request.Locale).ConfigureAwait(false);
+                entries.Add(new ZipEntrySource(
+                    $"{LogFileExportFileName}_{timestamp}.csv",
+                    () => Task.FromResult<Stream>(new MemoryStream(logFileCsvBytes))));
+            }
+
+            if (request.WithAttachments == true)
+            {
+                var attachments = logFiles.Where(lf => lf.NameUuid != null && lf.Name != null).ToList();
+
+                // The archive is streamed, so the status code is committed as soon as the first
+                // byte reaches the response body. Probe every object up front, while returning a
+                // problem response is still possible.
+                var probes = await Task.WhenAll(attachments.Select(async logFile => new
                 {
-                    await logRunCsvStream.WriteAsync(logRunCsvBytes.AsMemory(0, logRunCsvBytes.Length)).ConfigureAwait(false);
+                    LogFile = logFile,
+                    Exists = await logFileCloudService.ObjectExists(logFile.NameUuid!).ConfigureAwait(false),
+                })).ConfigureAwait(false);
+
+                var missingFileNames = probes.Where(probe => !probe.Exists).Select(probe => probe.LogFile.Name).ToList();
+                if (missingFileNames.Count > 0)
+                {
+                    Logger.LogError("Log file attachments are missing in cloud storage: {MissingFiles}", string.Join(", ", missingFileNames));
+                    return Problem("An error occurred while fetching a file from the cloud storage.");
                 }
 
-                if (logFiles.Count > 0)
+                foreach (var logFile in attachments)
                 {
-                    var logFileCsvBytes = await WriteLogFileCsvBytesAsync(logFiles, request.Locale).ConfigureAwait(false);
-                    var logFileCsvEntry = archive.CreateEntry($"{LogFileExportFileName}_{timestamp}.csv", CompressionLevel.Fastest);
-                    using (var logFileCsvStream = await logFileCsvEntry.OpenAsync().ConfigureAwait(false))
-                    {
-                        await logFileCsvStream.WriteAsync(logFileCsvBytes.AsMemory(0, logFileCsvBytes.Length)).ConfigureAwait(false);
-                    }
-                }
-
-                if (request.WithAttachments == true)
-                {
-                    foreach (var logFile in logFiles.Where(lf => lf.NameUuid != null && lf.Name != null))
-                    {
-                        var fileBytes = await logFileCloudService.GetObject(logFile.NameUuid!).ConfigureAwait(false);
-
-                        var folderName = FileHelper.SanitizeZipEntryFileName(logFile.LogRun!.RunNumber, "run");
-                        var fileName = FileHelper.SanitizeZipEntryFileName(logFile.Name!, "export");
-                        var entryName = $"{folderName}/{fileName}";
-                        var zipEntry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
-                        using var zipEntryStream = await zipEntry.OpenAsync().ConfigureAwait(false);
-                        await zipEntryStream.WriteAsync(fileBytes.AsMemory(0, fileBytes.Length)).ConfigureAwait(false);
-                    }
+                    var folderName = FileHelper.SanitizeZipEntryFileName(logFile.LogRun!.RunNumber, "run");
+                    var fileName = FileHelper.SanitizeZipEntryFileName(logFile.Name!, "export");
+                    var nameUuid = logFile.NameUuid!;
+                    entries.Add(new ZipEntrySource(
+                        $"{folderName}/{fileName}",
+                        () => logFileCloudService.GetObjectStream(nameUuid)));
                 }
             }
 
-            return File(memoryStream.ToArray(), "application/zip", $"{LogExportFileName}_{timestamp}.zip");
+            return new StreamedZipResult($"{LogExportFileName}_{timestamp}.zip", entries);
         }
         catch (AmazonS3Exception ex)
         {

--- a/src/api/Controllers/LogController.cs
+++ b/src/api/Controllers/LogController.cs
@@ -723,7 +723,7 @@ public class LogController : BoreholeControllerBase<LogRun>
                 }
             }
 
-            return new StreamedZipResult($"{LogExportFileName}_{timestamp}.zip", entries);
+            return new StreamedZipResult($"{LogExportFileName}_{timestamp}.zip", entries, Logger);
         }
         catch (AmazonS3Exception ex)
         {

--- a/src/api/Services/CloudServiceBase.cs
+++ b/src/api/Services/CloudServiceBase.cs
@@ -86,10 +86,11 @@ public abstract class CloudServiceBase
     /// knows which file it was reading.
     /// </remarks>
     /// <param name="objectName">The name of the file in the bucket.</param>
+    /// <param name="cancellationToken">Aborts the request for the object.</param>
     /// <returns>A stream over the file content.</returns>
-    public async Task<Stream> GetObjectStream(string objectName)
+    public async Task<Stream> GetObjectStream(string objectName, CancellationToken cancellationToken = default)
     {
-        return await S3Client.GetObjectStreamAsync(BucketName, objectName, null).ConfigureAwait(false);
+        return await S3Client.GetObjectStreamAsync(BucketName, objectName, null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -98,12 +99,13 @@ public abstract class CloudServiceBase
     /// meaningful error response is still possible.
     /// </summary>
     /// <param name="objectName">The name of the file in the bucket.</param>
+    /// <param name="cancellationToken">Aborts the probe.</param>
     /// <returns><c>true</c> if the file exists, <c>false</c> if it does not.</returns>
-    public async Task<bool> ObjectExists(string objectName)
+    public async Task<bool> ObjectExists(string objectName, CancellationToken cancellationToken = default)
     {
         try
         {
-            await S3Client.GetObjectMetadataAsync(BucketName, objectName).ConfigureAwait(false);
+            await S3Client.GetObjectMetadataAsync(BucketName, objectName, cancellationToken).ConfigureAwait(false);
             return true;
         }
         catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)

--- a/src/api/Services/CloudServiceBase.cs
+++ b/src/api/Services/CloudServiceBase.cs
@@ -79,19 +79,17 @@ public abstract class CloudServiceBase
     /// and must dispose it. Prefer this over <see cref="GetObject"/> unless the whole payload is
     /// genuinely required in memory, because this does not buffer the object.
     /// </summary>
+    /// <remarks>
+    /// Failures are not logged here, unlike in the buffering methods of this class. Only the
+    /// initial request happens inside this method; the content is transferred while the caller
+    /// reads the stream, so the caller is the only place that sees the whole failure surface and
+    /// knows which file it was reading.
+    /// </remarks>
     /// <param name="objectName">The name of the file in the bucket.</param>
     /// <returns>A stream over the file content.</returns>
     public async Task<Stream> GetObjectStream(string objectName)
     {
-        try
-        {
-            return await S3Client.GetObjectStreamAsync(BucketName, objectName, null).ConfigureAwait(false);
-        }
-        catch (AmazonS3Exception ex)
-        {
-            Logger.LogError(ex, "Error opening file stream from cloud storage.");
-            throw;
-        }
+        return await S3Client.GetObjectStreamAsync(BucketName, objectName, null).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/api/Services/CloudServiceBase.cs
+++ b/src/api/Services/CloudServiceBase.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.S3;
 using Amazon.S3.Model;
+using System.Net;
 
 namespace BDMS.Services;
 
@@ -70,6 +71,46 @@ public abstract class CloudServiceBase
         {
             Logger.LogError(ex, "Error downloading file from cloud storage.");
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Opens a read stream for a file in the cloud storage. The caller owns the returned stream
+    /// and must dispose it. Prefer this over <see cref="GetObject"/> unless the whole payload is
+    /// genuinely required in memory, because this does not buffer the object.
+    /// </summary>
+    /// <param name="objectName">The name of the file in the bucket.</param>
+    /// <returns>A stream over the file content.</returns>
+    public async Task<Stream> GetObjectStream(string objectName)
+    {
+        try
+        {
+            return await S3Client.GetObjectStreamAsync(BucketName, objectName, null).ConfigureAwait(false);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            Logger.LogError(ex, "Error opening file stream from cloud storage.");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Checks whether a file exists in the cloud storage without transferring its content.
+    /// Used to validate a set of objects before a response body has been started, while a
+    /// meaningful error response is still possible.
+    /// </summary>
+    /// <param name="objectName">The name of the file in the bucket.</param>
+    /// <returns><c>true</c> if the file exists, <c>false</c> if it does not.</returns>
+    public async Task<bool> ObjectExists(string objectName)
+    {
+        try
+        {
+            await S3Client.GetObjectMetadataAsync(BucketName, objectName).ConfigureAwait(false);
+            return true;
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
         }
     }
 

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -18,16 +18,19 @@ namespace BDMS.Services;
 internal sealed class StreamedZipResult : IActionResult
 {
     private readonly IReadOnlyList<ZipEntrySource> entries;
+    private readonly ILogger logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StreamedZipResult"/> class.
     /// </summary>
     /// <param name="fileName">The file name offered to the client, including the .zip extension.</param>
     /// <param name="entries">The entries to write, in order.</param>
-    internal StreamedZipResult(string fileName, IReadOnlyList<ZipEntrySource> entries)
+    /// <param name="logger">Used to record which entry failed, since a mid-stream failure cannot be reported to the client.</param>
+    internal StreamedZipResult(string fileName, IReadOnlyList<ZipEntrySource> entries, ILogger logger)
     {
         FileName = fileName;
         this.entries = entries;
+        this.logger = logger;
     }
 
     /// <summary>
@@ -59,14 +62,63 @@ internal sealed class StreamedZipResult : IActionResult
 
         // leaveOpen keeps the response body usable by the server after the archive's central
         // directory has been written.
-        using var archive = new ZipArchive(response.Body, ZipArchiveMode.Create, leaveOpen: true);
-
-        foreach (var entry in entries)
+        var archive = new ZipArchive(response.Body, ZipArchiveMode.Create, leaveOpen: true);
+        try
         {
-            var zipEntry = archive.CreateEntry(entry.EntryName, CompressionLevel.Fastest);
-            using var zipEntryStream = zipEntry.Open();
+            foreach (var entry in entries)
+            {
+                await WriteEntryAsync(archive, entry).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            DisposeWithoutMaskingFailure(archive);
+            throw;
+        }
+
+        archive.Dispose();
+    }
+
+    /// <summary>
+    /// Writes one entry, ensuring the failure that explains the problem is the one that escapes.
+    /// The response has already started by this point, so a failure cannot become an error status
+    /// and the log is the only record of what went wrong.
+    /// </summary>
+    /// <param name="archive">The archive being written.</param>
+    /// <param name="entry">The entry to write.</param>
+    private async Task WriteEntryAsync(ZipArchive archive, ZipEntrySource entry)
+    {
+        var zipEntryStream = archive.CreateEntry(entry.EntryName, CompressionLevel.Fastest).Open();
+        try
+        {
             using var content = await entry.OpenContent().ConfigureAwait(false);
             await content.CopyToAsync(zipEntryStream).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to write entry {EntryName} into the streamed ZIP archive. The client receives a truncated archive.", entry.EntryName);
+            DisposeWithoutMaskingFailure(zipEntryStream);
+            throw;
+        }
+
+        await zipEntryStream.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Disposes part of a failed archive, swallowing any failure. Disposal flushes and writes
+    /// headers, and once an entry has failed those writes usually go to a broken stream. Letting
+    /// them escape would replace the exception that actually explains the failure.
+    /// </summary>
+    /// <param name="disposable">The archive or entry stream to dispose.</param>
+    private void DisposeWithoutMaskingFailure(IDisposable disposable)
+    {
+        try
+        {
+            disposable.Dispose();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Suppressed a failure while disposing part of a truncated ZIP archive.");
         }
     }
 }

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
+using System.IO.Compression;
+
+namespace BDMS.Services;
+
+/// <summary>
+/// Writes a ZIP archive directly to the response body, streaming each entry's content instead of
+/// buffering the archive or any single entry in memory. This removes the ~2 GB managed array
+/// ceiling and the peak memory multiplication of building an archive in a <see cref="MemoryStream"/>.
+/// </summary>
+/// <remarks>
+/// Once the first byte reaches the response body the status code is committed, so a failure while
+/// streaming cannot be turned into an error response. Callers must therefore validate everything
+/// they can, such as permissions and object existence, before returning this result.
+/// </remarks>
+internal sealed class StreamedZipResult : IActionResult
+{
+    private readonly string fileName;
+    private readonly IReadOnlyList<ZipEntrySource> entries;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamedZipResult"/> class.
+    /// </summary>
+    /// <param name="fileName">The file name offered to the client, including the .zip extension.</param>
+    /// <param name="entries">The entries to write, in order.</param>
+    internal StreamedZipResult(string fileName, IReadOnlyList<ZipEntrySource> entries)
+    {
+        this.fileName = fileName;
+        this.entries = entries;
+    }
+
+    /// <inheritdoc/>
+    public async Task ExecuteResultAsync(ActionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var response = context.HttpContext.Response;
+        response.ContentType = "application/zip";
+
+        var contentDisposition = new ContentDispositionHeaderValue("attachment");
+        contentDisposition.SetHttpFileName(fileName);
+        response.Headers.ContentDisposition = contentDisposition.ToString();
+
+        // leaveOpen keeps the response body usable by the server after the archive's central
+        // directory has been written.
+        using var archive = new ZipArchive(response.Body, ZipArchiveMode.Create, leaveOpen: true);
+
+        foreach (var entry in entries)
+        {
+            var zipEntry = archive.CreateEntry(entry.EntryName, CompressionLevel.Fastest);
+            using var zipEntryStream = zipEntry.Open();
+            using var content = await entry.OpenContent().ConfigureAwait(false);
+            await content.CopyToAsync(zipEntryStream).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -16,7 +16,6 @@ namespace BDMS.Services;
 /// </remarks>
 internal sealed class StreamedZipResult : IActionResult
 {
-    private readonly string fileName;
     private readonly IReadOnlyList<ZipEntrySource> entries;
 
     /// <summary>
@@ -26,9 +25,15 @@ internal sealed class StreamedZipResult : IActionResult
     /// <param name="entries">The entries to write, in order.</param>
     internal StreamedZipResult(string fileName, IReadOnlyList<ZipEntrySource> entries)
     {
-        this.fileName = fileName;
+        FileName = fileName;
         this.entries = entries;
     }
+
+    /// <summary>
+    /// Gets the file name offered to the client, including the .zip extension. Exposed so a
+    /// caller's tests can assert on the name without executing the result.
+    /// </summary>
+    internal string FileName { get; }
 
     /// <inheritdoc/>
     public async Task ExecuteResultAsync(ActionContext context)
@@ -39,7 +44,7 @@ internal sealed class StreamedZipResult : IActionResult
         response.ContentType = "application/zip";
 
         var contentDisposition = new ContentDispositionHeaderValue("attachment");
-        contentDisposition.SetHttpFileName(fileName);
+        contentDisposition.SetHttpFileName(FileName);
         response.Headers.ContentDisposition = contentDisposition.ToString();
 
         // leaveOpen keeps the response body usable by the server after the archive's central

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -43,18 +43,7 @@ internal sealed class StreamedZipResult : IActionResult
         ArgumentNullException.ThrowIfNull(context);
 
         var response = context.HttpContext.Response;
-
-        // ZipArchive has no internal async write path. Kestrel rejects synchronous writes on the response body by default,
-        // so it has to be enabled for this response or every export fails. A large export therefore
-        // blocks a thread pool thread while it drains to the socket. Memory stays bounded either way.
-        // TODO: https://github.com/swisstopo/swissgeol-boreholes-suite/issues/2995
-        // Remove this opt-in once the project targets .NET 10, which added ZipArchive.CreateAsync
-        // and ZipArchiveEntry.OpenAsync.
-        var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
-        if (bodyControl is not null)
-        {
-            bodyControl.AllowSynchronousIO = true;
-        }
+        var cancellationToken = context.HttpContext.RequestAborted;
 
         response.ContentType = "application/zip";
 
@@ -62,23 +51,37 @@ internal sealed class StreamedZipResult : IActionResult
         contentDisposition.SetHttpFileName(FileName);
         response.Headers.ContentDisposition = contentDisposition.ToString();
 
+        // The archive is built through the asynchronous API, so an entry's payload reaches the
+        // response body through WriteAsync. Closing an entry is still synchronous: the stream
+        // ZipArchiveEntry.OpenAsync returns does not override DisposeAsync, so disposal falls back
+        // to the synchronous chain and flushes the deflate buffer with blocking writes.
+        // Kestrel rejects those unless they are allowed for this response.
+        // TODO: https://github.com/swisstopo/swissgeol-boreholes-suite/issues/2995
+        // Drop this opt-in once the deployed runtime carries the fix for
+        // https://github.com/dotnet/runtime/issues/121624 (still reproducible on 10.0.11).
+        var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
+        if (bodyControl is not null)
+        {
+            bodyControl.AllowSynchronousIO = true;
+        }
+
         // leaveOpen keeps the response body usable by the server after the archive's central
         // directory has been written.
-        var archive = new ZipArchive(response.Body, ZipArchiveMode.Create, leaveOpen: true);
+        var archive = await ZipArchive.CreateAsync(response.Body, ZipArchiveMode.Create, leaveOpen: true, entryNameEncoding: null, cancellationToken).ConfigureAwait(false);
         try
         {
             foreach (var entry in entries)
             {
-                await WriteEntryAsync(archive, entry).ConfigureAwait(false);
+                await WriteEntryAsync(archive, entry, cancellationToken).ConfigureAwait(false);
             }
         }
         catch
         {
-            DisposeWithoutMaskingFailure(archive);
+            await DisposeWithoutMaskingFailureAsync(archive).ConfigureAwait(false);
             throw;
         }
 
-        archive.Dispose();
+        await archive.DisposeAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -88,18 +91,23 @@ internal sealed class StreamedZipResult : IActionResult
     /// </summary>
     /// <param name="archive">The archive being written.</param>
     /// <param name="entry">The entry to write.</param>
-    private async Task WriteEntryAsync(ZipArchive archive, ZipEntrySource entry)
+    /// <param name="cancellationToken">Aborts the write once the client is gone.</param>
+    private async Task WriteEntryAsync(ZipArchive archive, ZipEntrySource entry, CancellationToken cancellationToken)
     {
-        var zipEntryStream = archive.CreateEntry(entry.EntryName, CompressionLevel.Fastest).Open();
+        var zipEntry = archive.CreateEntry(entry.EntryName, CompressionLevel.Fastest);
+        var zipEntryStream = await zipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            using var content = await entry.OpenContent().ConfigureAwait(false);
-            await content.CopyToAsync(zipEntryStream).ConfigureAwait(false);
+            var content = await entry.OpenContent().ConfigureAwait(false);
+            await using (content.ConfigureAwait(false))
+            {
+                await content.CopyToAsync(zipEntryStream, cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to write entry {EntryName} into the streamed ZIP archive. The client receives a truncated archive.", entry.EntryName);
-            DisposeWithoutMaskingFailure(zipEntryStream);
+            await DisposeWithoutMaskingFailureAsync(zipEntryStream).ConfigureAwait(false);
             throw;
         }
 
@@ -112,11 +120,11 @@ internal sealed class StreamedZipResult : IActionResult
     /// them escape would replace the exception that actually explains the failure.
     /// </summary>
     /// <param name="disposable">The archive or entry stream to dispose.</param>
-    private void DisposeWithoutMaskingFailure(IDisposable disposable)
+    private async Task DisposeWithoutMaskingFailureAsync(IAsyncDisposable disposable)
     {
         try
         {
-            disposable.Dispose();
+            await disposable.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -7,8 +7,7 @@ namespace BDMS.Services;
 
 /// <summary>
 /// Writes a ZIP archive directly to the response body, streaming each entry's content instead of
-/// buffering the archive or any single entry in memory. This removes the ~2 GB managed array
-/// ceiling and the peak memory multiplication of building an archive in a <see cref="MemoryStream"/>.
+/// buffering the archive or any single entry in memory.
 /// </summary>
 /// <remarks>
 /// Once the first byte reaches the response body the status code is committed, so a failure while
@@ -34,8 +33,7 @@ internal sealed class StreamedZipResult : IActionResult
     }
 
     /// <summary>
-    /// Gets the file name offered to the client, including the .zip extension. Exposed so a
-    /// caller's tests can assert on the name without executing the result.
+    /// Gets the file name offered to the client, including the .zip extension.
     /// </summary>
     internal string FileName { get; }
 

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -54,11 +54,10 @@ internal sealed class StreamedZipResult : IActionResult
         // The archive is built through the asynchronous API, so an entry's payload reaches the
         // response body through WriteAsync. Closing an entry is still synchronous: the stream
         // ZipArchiveEntry.OpenAsync returns does not override DisposeAsync, so disposal falls back
-        // to the synchronous chain and flushes the deflate buffer with blocking writes.
-        // Kestrel rejects those unless they are allowed for this response.
-        // TODO: https://github.com/swisstopo/swissgeol-boreholes-suite/issues/2995
-        // Drop this opt-in once the deployed runtime carries the fix for
-        // https://github.com/dotnet/runtime/issues/121624 (still reproducible on 10.0.11).
+        // to the synchronous chain and flushes the deflate buffer with blocking writes. Kestrel
+        // rejects those unless they are allowed for this response.
+        // TODO: Drop this opt-in once the deployed runtime carries the fix for
+        // https://github.com/dotnet/runtime/issues/121624, still reproducible on 10.0.11.
         var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
         if (bodyControl is not null)
         {

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
 using System.IO.Compression;
 
@@ -41,6 +42,15 @@ internal sealed class StreamedZipResult : IActionResult
         ArgumentNullException.ThrowIfNull(context);
 
         var response = context.HttpContext.Response;
+
+        // ZipArchive has no internal async write path. Kestrel rejects synchronous writes on the response body by default,
+        // so it has to be enabled for this response or every export fails.
+        var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
+        if (bodyControl != null)
+        {
+            bodyControl.AllowSynchronousIO = true;
+        }
+
         response.ContentType = "application/zip";
 
         var contentDisposition = new ContentDispositionHeaderValue("attachment");

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -24,7 +24,7 @@ internal sealed class StreamedZipResult : IActionResult
     /// </summary>
     /// <param name="fileName">The file name offered to the client, including the .zip extension.</param>
     /// <param name="entries">The entries to write, in order.</param>
-    /// <param name="logger">Used to record which entry failed, since a mid-stream failure cannot be reported to the client.</param>
+    /// <param name="logger">Used to record the secondary failures that are suppressed while abandoning a truncated archive.</param>
     internal StreamedZipResult(string fileName, IReadOnlyList<ZipEntrySource> entries, ILogger logger)
     {
         FileName = fileName;
@@ -85,8 +85,9 @@ internal sealed class StreamedZipResult : IActionResult
 
     /// <summary>
     /// Writes one entry, ensuring the failure that explains the problem is the one that escapes.
-    /// The response has already started by this point, so a failure cannot become an error status
-    /// and the log is the only record of what went wrong.
+    /// The response has already started by this point, so a failure cannot become an error status.
+    /// It therefore carries the entry name, because the exception is the only thing that reaches
+    /// the pipeline's log and nothing further up knows which entry was being written.
     /// </summary>
     /// <param name="archive">The archive being written.</param>
     /// <param name="entry">The entry to write.</param>
@@ -97,7 +98,7 @@ internal sealed class StreamedZipResult : IActionResult
         var zipEntryStream = await zipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var content = await entry.OpenContent().ConfigureAwait(false);
+            var content = await entry.OpenContent(cancellationToken).ConfigureAwait(false);
             await using (content.ConfigureAwait(false))
             {
                 await content.CopyToAsync(zipEntryStream, cancellationToken).ConfigureAwait(false);
@@ -105,9 +106,13 @@ internal sealed class StreamedZipResult : IActionResult
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to write entry {EntryName} into the streamed ZIP archive. The client receives a truncated archive.", entry.EntryName);
             await DisposeWithoutMaskingFailureAsync(zipEntryStream).ConfigureAwait(false);
-            throw;
+
+            // A client that gave up is not a broken export, so cancellation keeps its own type
+            // instead of being reported as a failure of this entry.
+            if (ex is OperationCanceledException) throw;
+
+            throw new InvalidOperationException($"Failed to write entry '{entry.EntryName}' into the streamed ZIP archive. The client receives a truncated archive.", ex);
         }
 
         await zipEntryStream.DisposeAsync().ConfigureAwait(false);

--- a/src/api/Services/StreamedZipResult.cs
+++ b/src/api/Services/StreamedZipResult.cs
@@ -47,9 +47,13 @@ internal sealed class StreamedZipResult : IActionResult
         var response = context.HttpContext.Response;
 
         // ZipArchive has no internal async write path. Kestrel rejects synchronous writes on the response body by default,
-        // so it has to be enabled for this response or every export fails.
+        // so it has to be enabled for this response or every export fails. A large export therefore
+        // blocks a thread pool thread while it drains to the socket. Memory stays bounded either way.
+        // TODO: https://github.com/swisstopo/swissgeol-boreholes-suite/issues/2995
+        // Remove this opt-in once the project targets .NET 10, which added ZipArchive.CreateAsync
+        // and ZipArchiveEntry.OpenAsync.
         var bodyControl = context.HttpContext.Features.Get<IHttpBodyControlFeature>();
-        if (bodyControl != null)
+        if (bodyControl is not null)
         {
             bodyControl.AllowSynchronousIO = true;
         }

--- a/src/api/Services/ZipEntrySource.cs
+++ b/src/api/Services/ZipEntrySource.cs
@@ -1,0 +1,11 @@
+﻿namespace BDMS.Services;
+
+/// <summary>
+/// One entry to be written into a streamed ZIP archive.
+/// </summary>
+/// <param name="EntryName">The path of the entry inside the archive, using forward slashes for folders.</param>
+/// <param name="OpenContent">
+/// Opens the entry content. Invoked once, at the moment the entry is written, so that only one
+/// entry's content is in flight at a time. The returned stream is disposed by the writer.
+/// </param>
+internal sealed record ZipEntrySource(string EntryName, Func<Task<Stream>> OpenContent);

--- a/src/api/Services/ZipEntrySource.cs
+++ b/src/api/Services/ZipEntrySource.cs
@@ -6,6 +6,8 @@
 /// <param name="EntryName">The path of the entry inside the archive, using forward slashes for folders.</param>
 /// <param name="OpenContent">
 /// Opens the entry content. Invoked once, at the moment the entry is written, so that only one
-/// entry's content is in flight at a time. The returned stream is disposed by the writer.
+/// entry's content is in flight at a time. The returned stream is disposed by the writer. The
+/// token it receives is aborted once the client is gone, so an implementation that fetches the
+/// content over the network must pass it on rather than run the fetch to completion.
 /// </param>
-internal sealed record ZipEntrySource(string EntryName, Func<Task<Stream>> OpenContent);
+internal sealed record ZipEntrySource(string EntryName, Func<CancellationToken, Task<Stream>> OpenContent);

--- a/src/client/openapi/swagger.json
+++ b/src/client/openapi/swagger.json
@@ -4258,6 +4258,7 @@
           }
         ],
         "requestBody": {
+          "description": "The log runs or log files to export.",
           "content": {
             "application/json": {
               "schema": {

--- a/src/client/src/api/generated/types.gen.ts
+++ b/src/client/src/api/generated/types.gen.ts
@@ -7473,6 +7473,9 @@ export type PostApiVbyVersionLogImportResponses = {
 };
 
 export type PostApiVbyVersionLogExportData = {
+  /**
+   * The log runs or log files to export.
+   */
   body?: LogExportRequest;
   path: {
     version: string;

--- a/tests/api/Controllers/LogControllerTest.cs
+++ b/tests/api/Controllers/LogControllerTest.cs
@@ -91,7 +91,7 @@ public class LogControllerTest : TestControllerBase
     [TestMethod]
     public async Task DownloadUnknownFileReturnsNotFound()
     {
-        var response = await controller.DownloadAsync(999999);
+        var response = await controller.DownloadAsync(999999, CancellationToken.None);
         ActionResultAssert.IsNotFound(response);
     }
 
@@ -107,7 +107,7 @@ public class LogControllerTest : TestControllerBase
             .ReturnsAsync(false);
 
         var uploadedFile = Context.LogFiles.Single(f => f.LogRunId == logRun.Id);
-        var response = await controller.DownloadAsync(uploadedFile.Id);
+        var response = await controller.DownloadAsync(uploadedFile.Id, CancellationToken.None);
         ActionResultAssert.IsUnauthorized(response);
     }
 
@@ -126,7 +126,7 @@ public class LogControllerTest : TestControllerBase
 
         var uploadedFile = Context.LogFiles.Single(f => f.Name == fileName);
 
-        response = await controller.DownloadAsync(uploadedFile.Id);
+        response = await controller.DownloadAsync(uploadedFile.Id, CancellationToken.None);
 
         var fileStreamResult = (FileStreamResult)response;
         using var downloadReader = new StreamReader(fileStreamResult.FileStream);
@@ -498,7 +498,7 @@ public class LogControllerTest : TestControllerBase
     public async Task ExportWithBothLogRunIdsAndLogFileIdsReturnsBadRequest()
     {
         var request = new LogExportRequest { LogRunIds = [1], LogFileIds = [1], WithAttachments = false };
-        var response = await controller.ExportAsync(request).ConfigureAwait(false);
+        var response = await controller.ExportAsync(request, CancellationToken.None).ConfigureAwait(false);
         var badRequest = response as BadRequestObjectResult;
         Assert.IsNotNull(badRequest);
         Assert.AreEqual("LogRunIds and LogFileIds should not be provided together.", badRequest.Value);
@@ -508,7 +508,7 @@ public class LogControllerTest : TestControllerBase
     public async Task ExportWithNeitherLogRunIdsNorLogFileIdsReturnsBadRequest()
     {
         var request = new LogExportRequest { WithAttachments = false };
-        var response = await controller.ExportAsync(request).ConfigureAwait(false);
+        var response = await controller.ExportAsync(request, CancellationToken.None).ConfigureAwait(false);
         var badRequest = response as BadRequestObjectResult;
         Assert.IsNotNull(badRequest);
         Assert.AreEqual("No ids were provided.", badRequest.Value);
@@ -518,7 +518,7 @@ public class LogControllerTest : TestControllerBase
     public async Task ExportWithEmptyLogRunIdsReturnsBadRequest()
     {
         var request = new LogExportRequest { LogRunIds = [], WithAttachments = false };
-        var response = await controller.ExportAsync(request).ConfigureAwait(false);
+        var response = await controller.ExportAsync(request, CancellationToken.None).ConfigureAwait(false);
         var badRequest = response as BadRequestObjectResult;
         Assert.IsNotNull(badRequest);
         Assert.AreEqual("No ids were provided.", badRequest.Value);
@@ -531,7 +531,7 @@ public class LogControllerTest : TestControllerBase
         var logRun = await AddCompleteTestLogRunForExportAsync(borehole.Id, "RUN-A");
         await UploadTestLogFile(logRun.Id);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         var fileResult = response as StreamedZipResult;
         Assert.IsNotNull(fileResult);
@@ -554,7 +554,7 @@ public class LogControllerTest : TestControllerBase
         var logRun = await AddCompleteTestLogRunForExportAsync(borehole.Id, "RUN-ATT");
         var uploadedFile = await UploadTestLogFile(logRun.Id);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = true, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = true, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
 
@@ -575,7 +575,7 @@ public class LogControllerTest : TestControllerBase
         // Add two tool type codes out of alphabetic order so we can verify sorting
         await SetLogFileToolTypeCodesAsync(uploadedFile.Id, [100003033, 100003032]);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         using var archive = await ExecuteZipResultAsync(response);
 
         var logRunCsvEntry = archive.Entries.Single(e => e.FullName.StartsWith(LogRunCsvPrefix));
@@ -605,7 +605,7 @@ public class LogControllerTest : TestControllerBase
         var logRun1 = await AddTestLogRunAsync(borehole.Id, "R1");
         var logRun2 = await AddTestLogRunAsync(borehole.Id, "R2");
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun1.Id, logRun2.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun1.Id, logRun2.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
         var logRunCsvEntry = archive.Entries.Single(e => e.FullName.StartsWith(LogRunCsvPrefix));
@@ -621,7 +621,7 @@ public class LogControllerTest : TestControllerBase
         var borehole = await AddTestBoreholeAsync();
         var logRun = await AddTestLogRunAsync(borehole.Id, "NO-FILES");
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
 
@@ -638,7 +638,7 @@ public class LogControllerTest : TestControllerBase
         var logRun1 = await AddTestLogRunAsync(borehole1.Id, "A1");
         var logRun2 = await AddTestLogRunAsync(borehole2.Id, "B1");
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun1.Id, logRun2.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun1.Id, logRun2.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         var badRequest = response as BadRequestObjectResult;
         Assert.IsNotNull(badRequest);
@@ -648,7 +648,7 @@ public class LogControllerTest : TestControllerBase
     [TestMethod]
     public async Task ExportLogRunsWithInexistentIdsReturnsNotFound()
     {
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [999_999_001, 999_999_002], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [999_999_001, 999_999_002], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         Assert.IsInstanceOfType(response, typeof(NotFoundResult));
     }
 
@@ -662,7 +662,7 @@ public class LogControllerTest : TestControllerBase
             .Setup(x => x.CanViewBoreholeAsync("sub_admin", borehole.Id))
             .ReturnsAsync(false);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         Assert.IsInstanceOfType(response, typeof(UnauthorizedResult));
     }
 
@@ -688,7 +688,7 @@ public class LogControllerTest : TestControllerBase
         await Context.LogRuns.AddAsync(logRun);
         await Context.SaveChangesAsync();
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = locale }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = locale }, CancellationToken.None).ConfigureAwait(false);
         using var archive = await ExecuteZipResultAsync(response);
         var logRunCsvEntry = archive.Entries.Single(e => e.FullName.StartsWith(LogRunCsvPrefix));
         var csv = ReadEntryAsText(logRunCsvEntry);
@@ -716,7 +716,7 @@ public class LogControllerTest : TestControllerBase
         Context.LogFiles.Add(orphanFile);
         await Context.SaveChangesAsync();
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = true, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = true, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         var objectResult = response as ObjectResult;
         Assert.IsNotNull(objectResult);
         var problem = (ProblemDetails)objectResult.Value!;
@@ -730,7 +730,7 @@ public class LogControllerTest : TestControllerBase
         var logRun = await AddCompleteTestLogRunForExportAsync(borehole.Id, "LF-01");
         var logFile = await UploadTestLogFile(logRun.Id);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
 
@@ -746,7 +746,7 @@ public class LogControllerTest : TestControllerBase
         var logRun = await AddCompleteTestLogRunForExportAsync(borehole.Id, "LF-ATT");
         var logFile = await UploadTestLogFile(logRun.Id);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = true, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = true, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
         Assert.AreEqual(3, archive.Entries.Count);
@@ -772,7 +772,7 @@ public class LogControllerTest : TestControllerBase
 
         await SetLogFileToolTypeCodesAsync(logFile.Id, [100003033, 100003032]);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
         var logFileCsv = ReadEntryAsText(archive.Entries.Single(e => e.FullName.StartsWith(LogFileCsvPrefix)));
@@ -813,7 +813,7 @@ public class LogControllerTest : TestControllerBase
         Context.LogFiles.Update(logFile);
         await Context.SaveChangesAsync();
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = locale }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = locale }, CancellationToken.None).ConfigureAwait(false);
 
         using var archive = await ExecuteZipResultAsync(response);
         var csv = ReadEntryAsText(archive.Entries.Single(e => e.FullName.StartsWith(LogFileCsvPrefix)));
@@ -830,7 +830,7 @@ public class LogControllerTest : TestControllerBase
         var logFile1 = await UploadTestLogFile(logRun1.Id);
         var logFile2 = await UploadTestLogFile(logRun2.Id);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile1.Id, logFile2.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile1.Id, logFile2.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
 
         var badRequest = response as BadRequestObjectResult;
         Assert.IsNotNull(badRequest);
@@ -840,7 +840,7 @@ public class LogControllerTest : TestControllerBase
     [TestMethod]
     public async Task ExportLogFilesWithInexistentIdsReturnsNotFound()
     {
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [999_999_101, 999_999_102], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [999_999_101, 999_999_102], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         Assert.IsInstanceOfType(response, typeof(NotFoundResult));
     }
 
@@ -855,7 +855,7 @@ public class LogControllerTest : TestControllerBase
             .Setup(x => x.CanViewBoreholeAsync("sub_admin", borehole.Id))
             .ReturnsAsync(false);
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         Assert.IsInstanceOfType(response, typeof(UnauthorizedResult));
     }
 
@@ -874,7 +874,7 @@ public class LogControllerTest : TestControllerBase
         Context.LogFiles.Add(orphanFile);
         await Context.SaveChangesAsync();
 
-        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [orphanFile.Id], WithAttachments = true, Locale = "en" }).ConfigureAwait(false);
+        var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [orphanFile.Id], WithAttachments = true, Locale = "en" }, CancellationToken.None).ConfigureAwait(false);
         var objectResult = response as ObjectResult;
         Assert.IsNotNull(objectResult);
         var problem = (ProblemDetails)objectResult.Value!;
@@ -1192,7 +1192,7 @@ public class LogControllerTest : TestControllerBase
         Assert.AreEqual(nameUuid, updatedLogFile.NameUuid, "NameUuid should not change because the upload links to the existing LogFile.");
 
         // Verify the upload actually linked the bytes to the existing LogFile by downloading them back.
-        var downloadResponse = await controller.DownloadAsync(updatedLogFile.Id);
+        var downloadResponse = await controller.DownloadAsync(updatedLogFile.Id, CancellationToken.None);
         var downloadedFile = (FileStreamResult)downloadResponse;
         Assert.AreEqual(importedFileName, downloadedFile.FileDownloadName);
         using var downloadedReader = new StreamReader(downloadedFile.FileStream);

--- a/tests/api/Controllers/LogControllerTest.cs
+++ b/tests/api/Controllers/LogControllerTest.cs
@@ -128,8 +128,9 @@ public class LogControllerTest : TestControllerBase
 
         response = await controller.DownloadAsync(uploadedFile.Id);
 
-        var fileContentResult = (FileContentResult)response;
-        string contentResult = Encoding.ASCII.GetString(fileContentResult.FileContents);
+        var fileStreamResult = (FileStreamResult)response;
+        using var downloadReader = new StreamReader(fileStreamResult.FileStream);
+        string contentResult = await downloadReader.ReadToEndAsync();
         Assert.AreEqual(content, contentResult);
 
         Assert.AreEqual(DateTime.UtcNow.Date, uploadedFile.Created?.Date);
@@ -1218,9 +1219,10 @@ public class LogControllerTest : TestControllerBase
 
         // Verify the upload actually linked the bytes to the existing LogFile by downloading them back.
         var downloadResponse = await controller.DownloadAsync(updatedLogFile.Id);
-        var downloadedFile = (FileContentResult)downloadResponse;
+        var downloadedFile = (FileStreamResult)downloadResponse;
         Assert.AreEqual(importedFileName, downloadedFile.FileDownloadName);
-        Assert.AreEqual(content, Encoding.ASCII.GetString(downloadedFile.FileContents));
+        using var downloadedReader = new StreamReader(downloadedFile.FileStream);
+        Assert.AreEqual(content, await downloadedReader.ReadToEndAsync());
     }
 
     [TestMethod]

--- a/tests/api/Controllers/LogControllerTest.cs
+++ b/tests/api/Controllers/LogControllerTest.cs
@@ -533,14 +533,13 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = response as FileContentResult;
+        var fileResult = response as StreamedZipResult;
         Assert.IsNotNull(fileResult);
-        Assert.AreEqual("application/zip", fileResult.ContentType);
-        StringAssert.StartsWith(fileResult.FileDownloadName, "log_export_");
-        StringAssert.EndsWith(fileResult.FileDownloadName, ".zip");
+        StringAssert.StartsWith(fileResult.FileName, "log_export_");
+        StringAssert.EndsWith(fileResult.FileName, ".zip");
 
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        // The zip content type is asserted inside ExecuteZipResultAsync for every export test.
+        using var archive = await ExecuteZipResultAsync(response);
 
         // Expect exactly 2 entries (log_runs CSV + log_files CSV), no attachment
         Assert.AreEqual(2, archive.Entries.Count);
@@ -557,11 +556,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = true, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = response as FileContentResult;
-        Assert.IsNotNull(fileResult);
-
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
 
         // 2 CSVs + 1 attachment
         Assert.AreEqual(3, archive.Entries.Count);
@@ -581,10 +576,7 @@ public class LogControllerTest : TestControllerBase
         await SetLogFileToolTypeCodesAsync(uploadedFile.Id, [100003033, 100003032]);
 
         var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
-        var fileResult = (FileContentResult)response;
-
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
 
         var logRunCsvEntry = archive.Entries.Single(e => e.FullName.StartsWith(LogRunCsvPrefix));
         var logRunCsv = ReadEntryAsText(logRunCsvEntry);
@@ -615,9 +607,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun1.Id, logRun2.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = (FileContentResult)response;
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
         var logRunCsvEntry = archive.Entries.Single(e => e.FullName.StartsWith(LogRunCsvPrefix));
         var logRunCsv = ReadEntryAsText(logRunCsvEntry);
 
@@ -633,9 +623,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = (FileContentResult)response;
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
 
         Assert.AreEqual(1, archive.Entries.Count);
         Assert.IsTrue(archive.Entries.Single().FullName.StartsWith(LogRunCsvPrefix));
@@ -701,10 +689,7 @@ public class LogControllerTest : TestControllerBase
         await Context.SaveChangesAsync();
 
         var response = await controller.ExportAsync(new LogExportRequest { LogRunIds = [logRun.Id], WithAttachments = false, Locale = locale }).ConfigureAwait(false);
-        var fileResult = (FileContentResult)response;
-
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
         var logRunCsvEntry = archive.Entries.Single(e => e.FullName.StartsWith(LogRunCsvPrefix));
         var csv = ReadEntryAsText(logRunCsvEntry);
 
@@ -747,12 +732,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = response as FileContentResult;
-        Assert.IsNotNull(fileResult);
-        Assert.AreEqual("application/zip", fileResult.ContentType);
-
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
 
         Assert.AreEqual(2, archive.Entries.Count);
         Assert.IsTrue(archive.Entries.Any(e => e.FullName.StartsWith(LogRunCsvPrefix) && e.FullName.EndsWith(".csv")));
@@ -768,9 +748,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = true, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = (FileContentResult)response;
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
         Assert.AreEqual(3, archive.Entries.Count);
         Assert.IsNotNull(archive.Entries.SingleOrDefault(e => e.FullName == $"LF-ATT/{logFile.Name}"));
     }
@@ -796,9 +774,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = "en" }).ConfigureAwait(false);
 
-        var fileResult = (FileContentResult)response;
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
         var logFileCsv = ReadEntryAsText(archive.Entries.Single(e => e.FullName.StartsWith(LogFileCsvPrefix)));
 
         var lines = logFileCsv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
@@ -839,9 +815,7 @@ public class LogControllerTest : TestControllerBase
 
         var response = await controller.ExportAsync(new LogExportRequest { LogFileIds = [logFile.Id], WithAttachments = false, Locale = locale }).ConfigureAwait(false);
 
-        var fileResult = (FileContentResult)response;
-        using var zipStream = new MemoryStream(fileResult.FileContents);
-        using var archive = new ZipArchive(zipStream, ZipArchiveMode.Read);
+        using var archive = await ExecuteZipResultAsync(response);
         var csv = ReadEntryAsText(archive.Entries.Single(e => e.FullName.StartsWith(LogFileCsvPrefix)));
         var fields = csv.Split("\r\n", StringSplitOptions.RemoveEmptyEntries)[1].Split(';');
         Assert.AreEqual(expected, fields[9]);
@@ -1310,5 +1284,28 @@ public class LogControllerTest : TestControllerBase
         using var stream = entry.Open();
         using var reader = new StreamReader(stream, Encoding.UTF8);
         return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// Executes a streamed ZIP result against an in-memory response body and returns the archive,
+    /// so assertions keep working now that the export no longer returns a buffered byte array.
+    /// </summary>
+    private static async Task<ZipArchive> ExecuteZipResultAsync(IActionResult response)
+    {
+        var streamedZipResult = response as StreamedZipResult;
+        Assert.IsNotNull(streamedZipResult, $"Expected a StreamedZipResult but got {response?.GetType().Name ?? "null"}.");
+
+        var httpContext = new DefaultHttpContext();
+        var body = new MemoryStream();
+        httpContext.Response.Body = body;
+
+        // ExecuteResultAsync only reads HttpContext.Response, so the other ActionContext
+        // members are deliberately left unset.
+        await streamedZipResult.ExecuteResultAsync(new ActionContext { HttpContext = httpContext });
+
+        Assert.AreEqual("application/zip", httpContext.Response.ContentType);
+
+        body.Position = 0;
+        return new ZipArchive(body, ZipArchiveMode.Read);
     }
 }

--- a/tests/api/Services/LogFileCloudServiceTest.cs
+++ b/tests/api/Services/LogFileCloudServiceTest.cs
@@ -14,6 +14,7 @@ namespace BDMS.Services;
 [TestClass]
 public class LogFileCloudServiceTest
 {
+    private const string TestLasFileName = "file_1.las";
     private BdmsContext context;
     private AmazonS3Client s3Client;
     private string bucketName;
@@ -85,7 +86,7 @@ public class LogFileCloudServiceTest
     public async Task UploadObjectSameFileTwiceShouldReplaceFileInCloudStorage()
     {
         var content = Guid.NewGuid().ToString();
-        var formFile = GetFormFileByContent(content, "file_1.las");
+        var formFile = GetFormFileByContent(content, TestLasFileName);
 
         // Upload file
         await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
@@ -121,7 +122,7 @@ public class LogFileCloudServiceTest
     public async Task GetObjectShouldReturnFileBytes()
     {
         var content = Guid.NewGuid().ToString();
-        var formFile = GetFormFileByContent(content, "file_1.las");
+        var formFile = GetFormFileByContent(content, TestLasFileName);
 
         await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
         var result = await logFileCloudService.GetObject(formFile.FileName);
@@ -132,7 +133,7 @@ public class LogFileCloudServiceTest
     public async Task GetObjectStreamShouldReturnFileContent()
     {
         var content = Guid.NewGuid().ToString();
-        var formFile = GetFormFileByContent(content, "file_1.las");
+        var formFile = GetFormFileByContent(content, TestLasFileName);
 
         await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
 
@@ -150,7 +151,7 @@ public class LogFileCloudServiceTest
     [TestMethod]
     public async Task ObjectExistsShouldDistinguishPresentFromMissingObject()
     {
-        var formFile = GetFormFileByContent(Guid.NewGuid().ToString(), "file_1.las");
+        var formFile = GetFormFileByContent(Guid.NewGuid().ToString(), TestLasFileName);
 
         await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
 
@@ -162,7 +163,7 @@ public class LogFileCloudServiceTest
     public async Task DeleteObjectShouldDeleteObjectFromStorage()
     {
         var content = Guid.NewGuid().ToString();
-        var formFile = GetFormFileByContent(content, "file_1.las");
+        var formFile = GetFormFileByContent(content, TestLasFileName);
 
         await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
         await logFileCloudService.GetObject(formFile.FileName);

--- a/tests/api/Services/LogFileCloudServiceTest.cs
+++ b/tests/api/Services/LogFileCloudServiceTest.cs
@@ -129,6 +129,36 @@ public class LogFileCloudServiceTest
     }
 
     [TestMethod]
+    public async Task GetObjectStreamShouldReturnFileContent()
+    {
+        var content = Guid.NewGuid().ToString();
+        var formFile = GetFormFileByContent(content, "file_1.las");
+
+        await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
+
+        using var stream = await logFileCloudService.GetObjectStream(formFile.FileName);
+        using var reader = new StreamReader(stream);
+        Assert.AreEqual(content, await reader.ReadToEndAsync());
+    }
+
+    [TestMethod]
+    public async Task GetObjectStreamWithNotExistingObjectNameShouldThrowException()
+    {
+        await Assert.ThrowsExactlyAsync<AmazonS3Exception>(() => logFileCloudService.GetObjectStream("doesNotExist"));
+    }
+
+    [TestMethod]
+    public async Task ObjectExistsShouldDistinguishPresentFromMissingObject()
+    {
+        var formFile = GetFormFileByContent(Guid.NewGuid().ToString(), "file_1.las");
+
+        await logFileCloudService.UploadObject(formFile.OpenReadStream(), formFile.FileName, formFile.ContentType);
+
+        Assert.IsTrue(await logFileCloudService.ObjectExists(formFile.FileName));
+        Assert.IsFalse(await logFileCloudService.ObjectExists("doesNotExist"));
+    }
+
+    [TestMethod]
     public async Task DeleteObjectShouldDeleteObjectFromStorage()
     {
         var content = Guid.NewGuid().ToString();

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -62,7 +62,7 @@ public class StreamedZipResultTest
         var currentlyOpen = 0;
         var maxConcurrentlyOpen = 0;
 
-        Func<CancellationToken, Task<Stream>> openContent = () =>
+        Func<CancellationToken, Task<Stream>> openContent = _ =>
         {
             currentlyOpen++;
             maxConcurrentlyOpen = Math.Max(maxConcurrentlyOpen, currentlyOpen);
@@ -109,7 +109,7 @@ public class StreamedZipResultTest
         var payload = new byte[512 * 1024];
         Random.Shared.NextBytes(payload);
 
-        var entries = new[] { new ZipEntrySource("large.bin", () => Task.FromResult<Stream>(new MemoryStream(payload))) };
+        var entries = new[] { new ZipEntrySource("large.bin", _ => Task.FromResult<Stream>(new MemoryStream(payload))) };
 
         await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance)
             .ExecuteResultAsync(CreateActionContext(httpContext));
@@ -153,7 +153,7 @@ public class StreamedZipResultTest
 
         var entries = new[]
         {
-            new ZipEntrySource(FirstEntryName, () =>
+            new ZipEntrySource(FirstEntryName, _ =>
             {
                 clientGone.Cancel();
                 return Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(FirstEntryContent)));
@@ -180,7 +180,7 @@ public class StreamedZipResultTest
         var entries = new[]
         {
             CreateEntrySource(FirstEntryName, FirstEntryContent),
-            new ZipEntrySource("broken.txt", () =>
+            new ZipEntrySource("broken.txt", _ =>
             {
                 body.Break();
                 throw new InvalidOperationException("attachment gone from cloud storage");
@@ -242,7 +242,7 @@ public class StreamedZipResultTest
         using var body = new WriteCountingStream();
         httpContext.Response.Body = body;
 
-        var entries = new[] { new ZipEntrySource("huge.bin", () => Task.FromResult<Stream>(new PatternStream(entryLength))) };
+        var entries = new[] { new ZipEntrySource("huge.bin", _ => Task.FromResult<Stream>(new PatternStream(entryLength))) };
 
         await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance)
             .ExecuteResultAsync(CreateActionContext(httpContext));
@@ -280,7 +280,7 @@ public class StreamedZipResultTest
     }
 
     private static ZipEntrySource CreateEntrySource(string entryName, string content) =>
-        new(entryName, () => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(content))));
+        new(entryName, _ => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(content))));
 
     // ExecuteResultAsync only reads HttpContext.Response, so RouteData and ActionDescriptor
     // are deliberately left unset.

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
 using System.IO.Compression;
 using System.Text;
@@ -110,6 +111,31 @@ public class StreamedZipResultTest
         Assert.AreEqual(0, currentlyOpen, "A content stream was not disposed after its entry was written.");
     }
 
+    [TestMethod]
+    public async Task ExecuteResultAsyncEnablesSynchronousIoForTheResponseBody()
+    {
+        // ZipArchive has no internal async write path: it writes to its destination stream
+        // synchronously even when the caller only ever uses CopyToAsync on the entry streams.
+        // Kestrel rejects synchronous writes on the response body unless AllowSynchronousIO is
+        // enabled, so without opting in every real export fails with InvalidOperationException.
+        // A plain MemoryStream cannot observe that, which is why this guard stream exists.
+        var bodyControl = new TestBodyControlFeature { AllowSynchronousIO = false };
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<IHttpBodyControlFeature>(bodyControl);
+
+        using var body = new SynchronousIoGuardStream(bodyControl);
+        httpContext.Response.Body = body;
+
+        await new StreamedZipResult("test.zip", new[] { CreateEntrySource("first.txt", "content one") })
+            .ExecuteResultAsync(CreateActionContext(httpContext));
+
+        Assert.IsTrue(bodyControl.AllowSynchronousIO, "StreamedZipResult must enable synchronous IO before writing the archive.");
+
+        using var writtenBytes = new MemoryStream(body.ToArray());
+        using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
+        Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
+    }
+
     private static ZipEntrySource CreateEntrySource(string entryName, string content) =>
         new(entryName, () => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(content))));
 
@@ -143,6 +169,92 @@ public class StreamedZipResultTest
         {
             onDispose();
             base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Stands in for Kestrel's <see cref="IHttpBodyControlFeature"/>, which
+    /// <see cref="DefaultHttpContext"/> does not provide on its own.
+    /// </summary>
+    private sealed class TestBodyControlFeature : IHttpBodyControlFeature
+    {
+        public bool AllowSynchronousIO { get; set; }
+    }
+
+    /// <summary>
+    /// Mimics Kestrel's response body: synchronous writes throw unless synchronous IO has been
+    /// enabled through <see cref="IHttpBodyControlFeature"/>. Buffers everything written so a
+    /// test can read the result back.
+    /// </summary>
+    private sealed class SynchronousIoGuardStream : Stream
+    {
+        private readonly MemoryStream inner = new();
+        private readonly IHttpBodyControlFeature bodyControl;
+
+        internal SynchronousIoGuardStream(IHttpBodyControlFeature bodyControl) => this.bodyControl = bodyControl;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        internal byte[] ToArray() => inner.ToArray();
+
+        public override void Flush()
+        {
+            ThrowIfSynchronousIoDisallowed();
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ThrowIfSynchronousIoDisallowed();
+            inner.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            ThrowIfSynchronousIoDisallowed();
+            inner.WriteByte(value);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+            inner.WriteAsync(buffer, cancellationToken);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void ThrowIfSynchronousIoDisallowed()
+        {
+            if (!bodyControl.AllowSynchronousIO)
+            {
+                throw new InvalidOperationException("Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
+            }
         }
     }
 

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.IO.Compression;
 using System.Text;
 
@@ -22,7 +23,7 @@ public class StreamedZipResultTest
         using var body = new MemoryStream();
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", entries).ExecuteResultAsync(CreateActionContext(httpContext));
+        await new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
 
         body.Position = 0;
         using var archive = new ZipArchive(body, ZipArchiveMode.Read);
@@ -49,7 +50,7 @@ public class StreamedZipResultTest
         using var body = new NonSeekableWriteStream();
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", entries).ExecuteResultAsync(CreateActionContext(httpContext));
+        await new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
 
         using var writtenBytes = new MemoryStream(body.ToArray());
         using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
@@ -66,7 +67,7 @@ public class StreamedZipResultTest
         using var body = new MemoryStream();
         httpContext.Response.Body = body;
 
-        var result = new StreamedZipResult("log_export_20260902.zip", new[] { CreateEntrySource("a.txt", "a") });
+        var result = new StreamedZipResult("log_export_20260902.zip", new[] { CreateEntrySource("a.txt", "a") }, NullLogger.Instance);
         await result.ExecuteResultAsync(CreateActionContext(httpContext));
 
         var contentDisposition = httpContext.Response.Headers.ContentDisposition.ToString();
@@ -101,7 +102,7 @@ public class StreamedZipResultTest
         using var body = new MemoryStream();
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", entries).ExecuteResultAsync(CreateActionContext(httpContext));
+        await new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
 
         body.Position = 0;
         using var archive = new ZipArchive(body, ZipArchiveMode.Read);
@@ -126,7 +127,7 @@ public class StreamedZipResultTest
         using var body = new SynchronousIoGuardStream(bodyControl);
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", new[] { CreateEntrySource("first.txt", "content one") })
+        await new StreamedZipResult("test.zip", new[] { CreateEntrySource("first.txt", "content one") }, NullLogger.Instance)
             .ExecuteResultAsync(CreateActionContext(httpContext));
 
         Assert.IsTrue(bodyControl.AllowSynchronousIO, "StreamedZipResult must enable synchronous IO before writing the archive.");
@@ -134,6 +135,33 @@ public class StreamedZipResultTest
         using var writtenBytes = new MemoryStream(body.ToArray());
         using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
         Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsyncSurfacesTheEntryFailureRatherThanTheDisposalFailure()
+    {
+        // When an entry fails after the response has started, disposing the entry stream and the
+        // archive flushes headers to a stream that is usually broken as well. Those secondary
+        // failures must not replace the one that explains what actually went wrong, because the
+        // log is the only record the operator gets.
+        var httpContext = new DefaultHttpContext();
+        using var body = new BreakableStream();
+        httpContext.Response.Body = body;
+
+        var entries = new[]
+        {
+            CreateEntrySource("first.txt", "content one"),
+            new ZipEntrySource("broken.txt", () =>
+            {
+                body.Break();
+                throw new InvalidOperationException("attachment gone from cloud storage");
+            }),
+        };
+
+        var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            () => new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext)));
+
+        Assert.AreEqual("attachment gone from cloud storage", exception.Message);
     }
 
     private static ZipEntrySource CreateEntrySource(string entryName, string content) =>
@@ -169,6 +197,74 @@ public class StreamedZipResultTest
         {
             onDispose();
             base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// Buffers writes until <see cref="Break"/> is called, after which every write fails the way
+    /// a dead client connection would.
+    /// </summary>
+    private sealed class BreakableStream : Stream
+    {
+        private readonly MemoryStream inner = new();
+        private bool broken;
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        internal void Break() => broken = true;
+
+        public override void Flush()
+        {
+            ThrowIfBroken();
+            inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ThrowIfBroken();
+            inner.Write(buffer, offset, count);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            ThrowIfBroken();
+            inner.WriteByte(value);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void ThrowIfBroken()
+        {
+            if (broken)
+            {
+                throw new IOException("The response stream is no longer writable.");
+            }
         }
     }
 

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -62,7 +62,7 @@ public class StreamedZipResultTest
         var currentlyOpen = 0;
         var maxConcurrentlyOpen = 0;
 
-        Func<Task<Stream>> openContent = () =>
+        Func<CancellationToken, Task<Stream>> openContent = () =>
         {
             currentlyOpen++;
             maxConcurrentlyOpen = Math.Max(maxConcurrentlyOpen, currentlyOpen);
@@ -172,7 +172,7 @@ public class StreamedZipResultTest
         // When an entry fails after the response has started, disposing the entry stream and the
         // archive flushes headers to a stream that is usually broken as well. Those secondary
         // failures must not replace the one that explains what actually went wrong, because the
-        // log is the only record the operator gets.
+        // exception the pipeline logs is the only record the operator gets.
         var httpContext = new DefaultHttpContext();
         using var body = new BreakableStream();
         httpContext.Response.Body = body;
@@ -190,7 +190,39 @@ public class StreamedZipResultTest
         var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
             () => new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext)));
 
-        Assert.AreEqual("attachment gone from cloud storage", exception.Message);
+        // The entry name only exists at the point of failure, so it travels on the exception
+        // rather than in a log statement here.
+        StringAssert.Contains(exception.Message, "broken.txt");
+        Assert.AreEqual("attachment gone from cloud storage", exception.InnerException?.Message);
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsyncPassesTheClientDisconnectTokenToTheContentSource()
+    {
+        // An attachment is fetched from cloud storage while the archive is being written, so the
+        // token has to reach the content source. Without it a client that gives up mid-download
+        // leaves the fetch for a multi-gigabyte object running to completion.
+        using var clientGone = new CancellationTokenSource();
+        var httpContext = new DefaultHttpContext { RequestAborted = clientGone.Token };
+        httpContext.Features.Set<IHttpBodyControlFeature>(new TestBodyControlFeature());
+
+        using var body = new MemoryStream();
+        httpContext.Response.Body = body;
+
+        CancellationToken observedToken = default;
+        var entries = new[]
+        {
+            new ZipEntrySource(FirstEntryName, token =>
+            {
+                observedToken = token;
+                return Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(FirstEntryContent)));
+            }),
+        };
+
+        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance)
+            .ExecuteResultAsync(CreateActionContext(httpContext));
+
+        Assert.AreEqual(clientGone.Token, observedToken, "The content source must receive the token that is aborted when the client disconnects.");
     }
 
     [TestMethod]
@@ -225,7 +257,7 @@ public class StreamedZipResultTest
 
         // Reading a ZIP entry does not verify its checksum, so the content is compared against a
         // second generator rather than trusted because the sizes agree.
-        using var actualContent = entry.Open();
+        using var actualContent = await entry.OpenAsync();
         using var expectedContent = new PatternStream(entryLength);
         var actualBuffer = new byte[1024 * 1024];
         var expectedBuffer = new byte[actualBuffer.Length];

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -1,0 +1,193 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.IO.Compression;
+using System.Text;
+
+namespace BDMS.Services;
+
+[TestClass]
+public class StreamedZipResultTest
+{
+    [TestMethod]
+    public async Task ExecuteResultAsyncWritesEveryEntryWithItsContent()
+    {
+        var entries = new[]
+        {
+            CreateEntrySource("first.txt", "content one"),
+            CreateEntrySource("folder/second.txt", "content two"),
+        };
+
+        var httpContext = new DefaultHttpContext();
+        using var body = new MemoryStream();
+        httpContext.Response.Body = body;
+
+        await new StreamedZipResult("test.zip", entries).ExecuteResultAsync(CreateActionContext(httpContext));
+
+        body.Position = 0;
+        using var archive = new ZipArchive(body, ZipArchiveMode.Read);
+
+        Assert.AreEqual(2, archive.Entries.Count);
+        Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
+        Assert.AreEqual("content two", ReadEntry(archive, "folder/second.txt"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsyncWritesValidArchiveToNonSeekableResponseBody()
+    {
+        // Kestrel's response body cannot seek, which makes ZipArchive emit data descriptors
+        // instead of back-patching the local file headers. A seekable MemoryStream does not
+        // exercise that path, so this test writes through a forward-only stream like the real
+        // server does.
+        var entries = new[]
+        {
+            CreateEntrySource("first.txt", "content one"),
+            CreateEntrySource("folder/second.txt", "content two"),
+        };
+
+        var httpContext = new DefaultHttpContext();
+        using var body = new NonSeekableWriteStream();
+        httpContext.Response.Body = body;
+
+        await new StreamedZipResult("test.zip", entries).ExecuteResultAsync(CreateActionContext(httpContext));
+
+        using var writtenBytes = new MemoryStream(body.ToArray());
+        using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
+
+        Assert.AreEqual(2, archive.Entries.Count);
+        Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
+        Assert.AreEqual("content two", ReadEntry(archive, "folder/second.txt"));
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsyncSetsZipContentTypeAndAttachmentHeader()
+    {
+        var httpContext = new DefaultHttpContext();
+        using var body = new MemoryStream();
+        httpContext.Response.Body = body;
+
+        var result = new StreamedZipResult("log_export_20260902.zip", new[] { CreateEntrySource("a.txt", "a") });
+        await result.ExecuteResultAsync(CreateActionContext(httpContext));
+
+        var contentDisposition = httpContext.Response.Headers.ContentDisposition.ToString();
+
+        Assert.AreEqual("application/zip", httpContext.Response.ContentType);
+        Assert.IsTrue(contentDisposition.Contains("attachment", StringComparison.Ordinal), $"Expected an attachment disposition but got '{contentDisposition}'.");
+        Assert.IsTrue(contentDisposition.Contains("log_export_20260902.zip", StringComparison.Ordinal), $"Expected the file name in the disposition but got '{contentDisposition}'.");
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsyncKeepsOnlyOneContentStreamOpenAtATime()
+    {
+        var currentlyOpen = 0;
+        var maxConcurrentlyOpen = 0;
+
+        Func<Task<Stream>> openContent = () =>
+        {
+            currentlyOpen++;
+            maxConcurrentlyOpen = Math.Max(maxConcurrentlyOpen, currentlyOpen);
+            Stream stream = new TrackingStream(Encoding.UTF8.GetBytes("payload"), () => currentlyOpen--);
+            return Task.FromResult(stream);
+        };
+
+        var entries = new[]
+        {
+            new ZipEntrySource("a.txt", openContent),
+            new ZipEntrySource("b.txt", openContent),
+            new ZipEntrySource("c.txt", openContent),
+        };
+
+        var httpContext = new DefaultHttpContext();
+        using var body = new MemoryStream();
+        httpContext.Response.Body = body;
+
+        await new StreamedZipResult("test.zip", entries).ExecuteResultAsync(CreateActionContext(httpContext));
+
+        body.Position = 0;
+        using var archive = new ZipArchive(body, ZipArchiveMode.Read);
+
+        Assert.AreEqual(3, archive.Entries.Count);
+        Assert.AreEqual(1, maxConcurrentlyOpen, "More than one entry's content was materialized at the same time.");
+        Assert.AreEqual(0, currentlyOpen, "A content stream was not disposed after its entry was written.");
+    }
+
+    private static ZipEntrySource CreateEntrySource(string entryName, string content) =>
+        new(entryName, () => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(content))));
+
+    // ExecuteResultAsync only reads HttpContext.Response, so RouteData and ActionDescriptor
+    // are deliberately left unset.
+    private static ActionContext CreateActionContext(HttpContext httpContext) =>
+        new() { HttpContext = httpContext };
+
+    private static string ReadEntry(ZipArchive archive, string entryName)
+    {
+        using var stream = archive.Entries.Single(e => e.FullName == entryName).Open();
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    /// <summary>
+    /// A <see cref="MemoryStream"/> that reports its disposal, so a test can assert that the
+    /// writer released each entry's content stream.
+    /// </summary>
+    private sealed class TrackingStream : MemoryStream
+    {
+        private readonly Action onDispose;
+
+        internal TrackingStream(byte[] buffer, Action onDispose)
+            : base(buffer)
+        {
+            this.onDispose = onDispose;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            onDispose();
+            base.Dispose(disposing);
+        }
+    }
+
+    /// <summary>
+    /// A write-only, forward-only stream that stands in for Kestrel's response body, which
+    /// cannot seek. Buffers everything written so a test can read the result back.
+    /// </summary>
+    private sealed class NonSeekableWriteStream : Stream
+    {
+        private readonly MemoryStream inner = new();
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        internal byte[] ToArray() => inner.ToArray();
+
+        public override void Flush() => inner.Flush();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -92,13 +92,40 @@ public class StreamedZipResultTest
     }
 
     [TestMethod]
+    public async Task ExecuteResultAsyncWritesTheEntryPayloadAsynchronously()
+    {
+        // Guards the reason the archive is built through ZipArchive.CreateAsync and OpenAsync:
+        // an entry's payload, which is the bulk of a large export, must reach the response body
+        // through WriteAsync rather than blocking a thread pool thread per buffer. Closing an
+        // entry remains synchronous because the stream OpenAsync returns does not override
+        // DisposeAsync, so this asserts a ratio rather than the absence of synchronous writes.
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<IHttpBodyControlFeature>(new TestBodyControlFeature());
+
+        using var body = new WriteCountingStream();
+        httpContext.Response.Body = body;
+
+        // Incompressible content, so the archive cannot shrink the payload away.
+        var payload = new byte[512 * 1024];
+        Random.Shared.NextBytes(payload);
+
+        var entries = new[] { new ZipEntrySource("large.bin", () => Task.FromResult<Stream>(new MemoryStream(payload))) };
+
+        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance)
+            .ExecuteResultAsync(CreateActionContext(httpContext));
+
+        Assert.IsTrue(
+            body.AsynchronousByteCount > body.SynchronousByteCount * 2,
+            $"Expected the payload to be written asynchronously but only {body.AsynchronousByteCount} of {body.AsynchronousByteCount + body.SynchronousByteCount} bytes were.");
+    }
+
+    [TestMethod]
     public async Task ExecuteResultAsyncEnablesSynchronousIoForTheResponseBody()
     {
-        // ZipArchive has no internal async write path: it writes to its destination stream
-        // synchronously even when the caller only ever uses CopyToAsync on the entry streams.
-        // Kestrel rejects synchronous writes on the response body unless AllowSynchronousIO is
-        // enabled, so without opting in every real export fails with InvalidOperationException.
-        // A plain MemoryStream cannot observe that, which is why this guard stream exists.
+        // Closing a ZIP entry writes synchronously, and Kestrel rejects synchronous writes on the
+        // response body unless AllowSynchronousIO is enabled, so without opting in every real
+        // export fails with an InvalidOperationException. A plain MemoryStream cannot observe
+        // that, which is why the guard stream exists.
         var bodyControl = new TestBodyControlFeature { AllowSynchronousIO = false };
         var httpContext = new DefaultHttpContext();
         httpContext.Features.Set<IHttpBodyControlFeature>(bodyControl);
@@ -114,6 +141,29 @@ public class StreamedZipResultTest
         using var writtenBytes = new MemoryStream(body.ToArray());
         using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
         Assert.AreEqual(FirstEntryContent, ReadEntry(archive, FirstEntryName));
+    }
+
+    [TestMethod]
+    public async Task ExecuteResultAsyncStopsWritingWhenTheClientDisconnects()
+    {
+        using var clientGone = new CancellationTokenSource();
+        var httpContext = new DefaultHttpContext { RequestAborted = clientGone.Token };
+        using var body = new MemoryStream();
+        httpContext.Response.Body = body;
+
+        var entries = new[]
+        {
+            new ZipEntrySource(FirstEntryName, () =>
+            {
+                clientGone.Cancel();
+                return Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(FirstEntryContent)));
+            }),
+        };
+
+        // The concrete type depends on which layer observes the cancellation first, so the
+        // assertion deliberately accepts any cancellation exception.
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext)));
     }
 
     [TestMethod]
@@ -228,6 +278,24 @@ public class StreamedZipResultTest
             inner.WriteByte(value);
         }
 
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ThrowIfBroken();
+            return inner.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfBroken();
+            return inner.WriteAsync(buffer, cancellationToken);
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfBroken();
+            return inner.FlushAsync(cancellationToken);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)
@@ -261,12 +329,44 @@ public class StreamedZipResultTest
     /// enabled through <see cref="IHttpBodyControlFeature"/>. Buffers everything written so a
     /// test can read the result back.
     /// </summary>
-    private sealed class SynchronousIoGuardStream : Stream
+    private sealed class SynchronousIoGuardStream : WriteOnlyStream
     {
-        private readonly MemoryStream inner = new();
         private readonly IHttpBodyControlFeature bodyControl;
 
         internal SynchronousIoGuardStream(IHttpBodyControlFeature bodyControl) => this.bodyControl = bodyControl;
+
+        protected override void OnSynchronousWrite(int byteCount)
+        {
+            if (!bodyControl.AllowSynchronousIO)
+            {
+                throw new InvalidOperationException("Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Records how many bytes reached the response body synchronously and how many reached it
+    /// through the asynchronous write path.
+    /// </summary>
+    private sealed class WriteCountingStream : WriteOnlyStream
+    {
+        internal long SynchronousByteCount { get; private set; }
+
+        internal long AsynchronousByteCount { get; private set; }
+
+        protected override void OnSynchronousWrite(int byteCount) => SynchronousByteCount += byteCount;
+
+        protected override void OnAsynchronousWrite(int byteCount) => AsynchronousByteCount += byteCount;
+    }
+
+    /// <summary>
+    /// A write-only, non-seekable stream that stands in for Kestrel's response body. Buffers
+    /// everything written so a test can read the result back, and reports every write so a
+    /// derived class can observe whether it arrived synchronously.
+    /// </summary>
+    private abstract class WriteOnlyStream : Stream
+    {
+        private readonly MemoryStream inner = new();
 
         public override bool CanRead => false;
 
@@ -286,7 +386,7 @@ public class StreamedZipResultTest
 
         public override void Flush()
         {
-            ThrowIfSynchronousIoDisallowed();
+            OnSynchronousWrite(0);
             inner.Flush();
         }
 
@@ -298,74 +398,55 @@ public class StreamedZipResultTest
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            ThrowIfSynchronousIoDisallowed();
+            OnSynchronousWrite(count);
             inner.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            OnSynchronousWrite(buffer.Length);
+            inner.Write(buffer);
         }
 
         public override void WriteByte(byte value)
         {
-            ThrowIfSynchronousIoDisallowed();
+            OnSynchronousWrite(1);
             inner.WriteByte(value);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-            inner.WriteAsync(buffer, offset, count, cancellationToken);
-
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
-            inner.WriteAsync(buffer, cancellationToken);
-
-        protected override void Dispose(bool disposing)
+        public override Task FlushAsync(CancellationToken cancellationToken)
         {
-            if (disposing)
-            {
-                inner.Dispose();
-            }
-
-            base.Dispose(disposing);
+            OnAsynchronousWrite(0);
+            return inner.FlushAsync(cancellationToken);
         }
 
-        private void ThrowIfSynchronousIoDisallowed()
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (!bodyControl.AllowSynchronousIO)
-            {
-                throw new InvalidOperationException("Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.");
-            }
-        }
-    }
-
-    /// <summary>
-    /// A write-only, forward-only stream that stands in for Kestrel's response body, which
-    /// cannot seek. Buffers everything written so a test can read the result back.
-    /// </summary>
-    private sealed class NonSeekableWriteStream : Stream
-    {
-        private readonly MemoryStream inner = new();
-
-        public override bool CanRead => false;
-
-        public override bool CanSeek => false;
-
-        public override bool CanWrite => true;
-
-        public override long Length => throw new NotSupportedException();
-
-        public override long Position
-        {
-            get => throw new NotSupportedException();
-            set => throw new NotSupportedException();
+            OnAsynchronousWrite(count);
+            return inner.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
-        internal byte[] ToArray() => inner.ToArray();
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            OnAsynchronousWrite(buffer.Length);
+            return inner.WriteAsync(buffer, cancellationToken);
+        }
 
-        public override void Flush() => inner.Flush();
+        /// <summary>
+        /// Called before every synchronous write reaches the buffer.
+        /// </summary>
+        /// <param name="byteCount">The number of bytes being written, zero for a flush.</param>
+        protected virtual void OnSynchronousWrite(int byteCount)
+        {
+        }
 
-        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-
-        public override void SetLength(long value) => throw new NotSupportedException();
-
-        public override void Write(byte[] buffer, int offset, int count) => inner.Write(buffer, offset, count);
+        /// <summary>
+        /// Called before every asynchronous write reaches the buffer.
+        /// </summary>
+        /// <param name="byteCount">The number of bytes being written, zero for a flush.</param>
+        protected virtual void OnAsynchronousWrite(int byteCount)
+        {
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -193,6 +193,60 @@ public class StreamedZipResultTest
         Assert.AreEqual("attachment gone from cloud storage", exception.Message);
     }
 
+    [TestMethod]
+    [TestCategory("LongRunning")]
+    public async Task ExecuteResultAsyncWritesAnEntryLargerThanFourGigabytes()
+    {
+        // Guards the point of streaming the archive: an entry may be far larger than the 2 GB a
+        // managed array can hold and than the 4 GB an uncompressed size field can express, so the
+        // writer must neither buffer the entry nor truncate its size to 32 bits. The content is
+        // highly compressible on purpose, which keeps the archive itself small enough to read
+        // back while the entry's uncompressed size still crosses both boundaries.
+        const long entryLength = (4L * 1024 * 1024 * 1024) + (64 * 1024);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<IHttpBodyControlFeature>(new TestBodyControlFeature());
+
+        using var body = new WriteCountingStream();
+        httpContext.Response.Body = body;
+
+        var entries = new[] { new ZipEntrySource("huge.bin", () => Task.FromResult<Stream>(new PatternStream(entryLength))) };
+
+        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance)
+            .ExecuteResultAsync(CreateActionContext(httpContext));
+
+        using var writtenBytes = new MemoryStream(body.ToArray());
+        using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
+        var entry = archive.Entries.Single();
+
+        // A size this large can only be expressed through a ZIP64 extra field, so reading it back
+        // correctly also proves the archive was written as ZIP64.
+        Assert.AreEqual(entryLength, entry.Length);
+
+        // Reading a ZIP entry does not verify its checksum, so the content is compared against a
+        // second generator rather than trusted because the sizes agree.
+        using var actualContent = entry.Open();
+        using var expectedContent = new PatternStream(entryLength);
+        var actualBuffer = new byte[1024 * 1024];
+        var expectedBuffer = new byte[actualBuffer.Length];
+        long verifiedLength = 0;
+
+        while (true)
+        {
+            var readLength = await actualContent.ReadAsync(actualBuffer);
+            if (readLength == 0) break;
+
+            await expectedContent.ReadExactlyAsync(expectedBuffer.AsMemory(0, readLength));
+            Assert.IsTrue(
+                actualBuffer.AsSpan(0, readLength).SequenceEqual(expectedBuffer.AsSpan(0, readLength)),
+                $"The archived content differs from the source content at offset {verifiedLength}.");
+
+            verifiedLength += readLength;
+        }
+
+        Assert.AreEqual(entryLength, verifiedLength);
+    }
+
     private static ZipEntrySource CreateEntrySource(string entryName, string content) =>
         new(entryName, () => Task.FromResult<Stream>(new MemoryStream(Encoding.UTF8.GetBytes(content))));
 
@@ -312,6 +366,85 @@ public class StreamedZipResultTest
             {
                 throw new IOException("The response stream is no longer writable.");
             }
+        }
+    }
+
+    /// <summary>
+    /// Produces a deterministic byte pattern of an arbitrary length without materializing it, so
+    /// a test can stream more content than fits in memory. The pattern repeats over a short cycle
+    /// and therefore compresses to a fraction of its length.
+    /// </summary>
+    private sealed class PatternStream : Stream
+    {
+        // A prime cycle length keeps the pattern from aligning with the buffer sizes used around
+        // it, so an off-by-one in the writer cannot go unnoticed.
+        private static readonly byte[] Pattern = CreatePattern(251);
+
+        private readonly long length;
+        private long position;
+
+        internal PatternStream(long length) => this.length = length;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => length;
+
+        public override long Position
+        {
+            get => position;
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            var remainingLength = length - position;
+            if (remainingLength <= 0) return 0;
+
+            var readLength = (int)Math.Min(buffer.Length, remainingLength);
+            var writtenLength = 0;
+            while (writtenLength < readLength)
+            {
+                var patternOffset = (int)((position + writtenLength) % Pattern.Length);
+                var chunkLength = Math.Min(Pattern.Length - patternOffset, readLength - writtenLength);
+                Pattern.AsSpan(patternOffset, chunkLength).CopyTo(buffer.Slice(writtenLength, chunkLength));
+                writtenLength += chunkLength;
+            }
+
+            position += writtenLength;
+            return writtenLength;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            Task.FromResult(Read(buffer.AsSpan(offset, count)));
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(Read(buffer.Span));
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        private static byte[] CreatePattern(int cycleLength)
+        {
+            var pattern = new byte[cycleLength];
+            for (var i = 0; i < pattern.Length; i++)
+            {
+                pattern[i] = (byte)i;
+            }
+
+            return pattern;
         }
     }
 

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -40,33 +40,6 @@ public class StreamedZipResultTest
     }
 
     [TestMethod]
-    public async Task ExecuteResultAsyncWritesValidArchiveToNonSeekableResponseBody()
-    {
-        // Kestrel's response body cannot seek, which makes ZipArchive emit data descriptors
-        // instead of back-patching the local file headers. A seekable MemoryStream does not
-        // exercise that path, so this test writes through a forward-only stream like the real
-        // server does.
-        var entries = new[]
-        {
-            CreateEntrySource(FirstEntryName, FirstEntryContent),
-            CreateEntrySource(SecondEntryName, SecondEntryContent),
-        };
-
-        var httpContext = new DefaultHttpContext();
-        using var body = new NonSeekableWriteStream();
-        httpContext.Response.Body = body;
-
-        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
-
-        using var writtenBytes = new MemoryStream(body.ToArray());
-        using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
-
-        Assert.AreEqual(2, archive.Entries.Count);
-        Assert.AreEqual(FirstEntryContent, ReadEntry(archive, FirstEntryName));
-        Assert.AreEqual(SecondEntryContent, ReadEntry(archive, SecondEntryName));
-    }
-
-    [TestMethod]
     public async Task ExecuteResultAsyncSetsZipContentTypeAndAttachmentHeader()
     {
         var httpContext = new DefaultHttpContext();

--- a/tests/api/Services/StreamedZipResultTest.cs
+++ b/tests/api/Services/StreamedZipResultTest.cs
@@ -10,27 +10,33 @@ namespace BDMS.Services;
 [TestClass]
 public class StreamedZipResultTest
 {
+    private const string ZipFileName = "test.zip";
+    private const string FirstEntryName = "first.txt";
+    private const string FirstEntryContent = "content one";
+    private const string SecondEntryName = "folder/second.txt";
+    private const string SecondEntryContent = "content two";
+
     [TestMethod]
     public async Task ExecuteResultAsyncWritesEveryEntryWithItsContent()
     {
         var entries = new[]
         {
-            CreateEntrySource("first.txt", "content one"),
-            CreateEntrySource("folder/second.txt", "content two"),
+            CreateEntrySource(FirstEntryName, FirstEntryContent),
+            CreateEntrySource(SecondEntryName, SecondEntryContent),
         };
 
         var httpContext = new DefaultHttpContext();
         using var body = new MemoryStream();
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
+        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
 
         body.Position = 0;
         using var archive = new ZipArchive(body, ZipArchiveMode.Read);
 
         Assert.AreEqual(2, archive.Entries.Count);
-        Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
-        Assert.AreEqual("content two", ReadEntry(archive, "folder/second.txt"));
+        Assert.AreEqual(FirstEntryContent, ReadEntry(archive, FirstEntryName));
+        Assert.AreEqual(SecondEntryContent, ReadEntry(archive, SecondEntryName));
     }
 
     [TestMethod]
@@ -42,22 +48,22 @@ public class StreamedZipResultTest
         // server does.
         var entries = new[]
         {
-            CreateEntrySource("first.txt", "content one"),
-            CreateEntrySource("folder/second.txt", "content two"),
+            CreateEntrySource(FirstEntryName, FirstEntryContent),
+            CreateEntrySource(SecondEntryName, SecondEntryContent),
         };
 
         var httpContext = new DefaultHttpContext();
         using var body = new NonSeekableWriteStream();
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
+        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
 
         using var writtenBytes = new MemoryStream(body.ToArray());
         using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
 
         Assert.AreEqual(2, archive.Entries.Count);
-        Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
-        Assert.AreEqual("content two", ReadEntry(archive, "folder/second.txt"));
+        Assert.AreEqual(FirstEntryContent, ReadEntry(archive, FirstEntryName));
+        Assert.AreEqual(SecondEntryContent, ReadEntry(archive, SecondEntryName));
     }
 
     [TestMethod]
@@ -102,7 +108,7 @@ public class StreamedZipResultTest
         using var body = new MemoryStream();
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
+        await new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext));
 
         body.Position = 0;
         using var archive = new ZipArchive(body, ZipArchiveMode.Read);
@@ -127,14 +133,14 @@ public class StreamedZipResultTest
         using var body = new SynchronousIoGuardStream(bodyControl);
         httpContext.Response.Body = body;
 
-        await new StreamedZipResult("test.zip", new[] { CreateEntrySource("first.txt", "content one") }, NullLogger.Instance)
+        await new StreamedZipResult(ZipFileName, new[] { CreateEntrySource(FirstEntryName, FirstEntryContent) }, NullLogger.Instance)
             .ExecuteResultAsync(CreateActionContext(httpContext));
 
         Assert.IsTrue(bodyControl.AllowSynchronousIO, "StreamedZipResult must enable synchronous IO before writing the archive.");
 
         using var writtenBytes = new MemoryStream(body.ToArray());
         using var archive = new ZipArchive(writtenBytes, ZipArchiveMode.Read);
-        Assert.AreEqual("content one", ReadEntry(archive, "first.txt"));
+        Assert.AreEqual(FirstEntryContent, ReadEntry(archive, FirstEntryName));
     }
 
     [TestMethod]
@@ -150,7 +156,7 @@ public class StreamedZipResultTest
 
         var entries = new[]
         {
-            CreateEntrySource("first.txt", "content one"),
+            CreateEntrySource(FirstEntryName, FirstEntryContent),
             new ZipEntrySource("broken.txt", () =>
             {
                 body.Break();
@@ -159,7 +165,7 @@ public class StreamedZipResultTest
         };
 
         var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
-            () => new StreamedZipResult("test.zip", entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext)));
+            () => new StreamedZipResult(ZipFileName, entries, NullLogger.Instance).ExecuteResultAsync(CreateActionContext(httpContext)));
 
         Assert.AreEqual("attachment gone from cloud storage", exception.Message);
     }


### PR DESCRIPTION
Fixes #2992 Log file export and single-file download now stream from S3 instead of buffering whole objects
in managed memory.
