### PR TITLE
Bump resource requirements to accomodate large file processing

### DIFF
--- a/charts/swissgeol-boreholes/templates/api.yaml
+++ b/charts/swissgeol-boreholes/templates/api.yaml
@@ -53,12 +53,12 @@ spec:
         resources:
           requests:
             cpu: 250m
-            memory: 512Mi
-            ephemeral-storage: 1Gi
+            memory: 2Gi
+            ephemeral-storage: 8Gi
           limits:
             cpu: 1000m
-            memory: 1Gi
-            ephemeral-storage: 2Gi
+            memory: 2Gi
+            ephemeral-storage: 16Gi
         securityContext:
           runAsNonRoot: true
           readOnlyRootFilesystem: true


### PR DESCRIPTION
- After discussion internally, @flenny noticed we have bottlenecks in our API which would make the processing of larger files impossible. Bumping the resource limits so that the pod is not killed when working with files larger than a 1-2 GiB
- Storage was made burstable in case the nodes are unusually full at the time of scheduling (quick check showed each node to have sub 100GiB total storage).